### PR TITLE
Score function interface

### DIFF
--- a/exploration/demo/Makefile
+++ b/exploration/demo/Makefile
@@ -1,0 +1,15 @@
+METADATA=metadata.csv
+
+.PHONY: all
+
+all: $(METADATA)
+	python evaluate.py $<
+
+out/samples-baseline.csv: fit_baseline_model.py $(METADATA)
+	python $< > $@
+
+out/samples-id.csv: fit_indep_div_model.py $(METADATA)
+	python $< $(METADATA) > $@
+
+$(METADATA): ../../data/load_metadata.py
+	python $< > $@

--- a/exploration/demo/evaluate.py
+++ b/exploration/demo/evaluate.py
@@ -8,6 +8,9 @@ import polars as pl
 
 from linmod.eval import proportions_mae
 
+score_functions = {"mae": proportions_mae}
+
+
 if len(sys.argv) != 2:
     print(
         "Usage: python3 evaluate.py <data_path>",
@@ -33,9 +36,8 @@ for samples_file in os.listdir("out/"):
     samples = pl.scan_csv(samples_file).drop_nulls()
     # TODO: where is the row of nulls coming from
 
-    scores[samples_file.stem] = (
-        proportions_mae(samples, data).collect().get_column("mae").sum()
-    )
+    for score_name, score_func in score_functions.items():
+        scores[(samples_file.stem, score_name)] = score_func(samples, data)
 
 for name, score in scores.items():
     print(f"{name}: {score}")

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -16,7 +16,9 @@ def proportions_mae_per_division_day(samples, data) -> pl.DataFrame:
     return (
         (
             data.with_columns(
-                phi=(pl.col("count") / pl.sum("count").over("division", "day")),
+                phi=(
+                    pl.col("count") / pl.sum("count").over("division", "day")
+                ),
             )
             .drop("count")
             .join(
@@ -38,4 +40,6 @@ def proportions_mae(
 ) -> float:
     """MAE on phi, summed over all lineages, divisions, and days"""
 
-    return proportions_mae(sample, data).collect().get_columns(score_column).sum()
+    return (
+        proportions_mae(sample, data).collect().get_columns(score_column).sum()
+    )

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -3,7 +3,7 @@ import polars as pl
 from linmod.utils import pl_mae
 
 
-def proportions_mae1(samples, data) -> pl.DataFrame:
+def proportions_mae_per_division_day(samples, data) -> pl.DataFrame:
     """
     A simple MAE on phi for each lineage-division-day.
 

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -3,7 +3,7 @@ import polars as pl
 from linmod.utils import pl_mae
 
 
-def proportions_mae(samples, data):
+def proportions_mae1(samples, data) -> pl.DataFrame:
     """
     A simple MAE on phi for each lineage-division-day.
 
@@ -16,9 +16,7 @@ def proportions_mae(samples, data):
     return (
         (
             data.with_columns(
-                phi=(
-                    pl.col("count") / pl.sum("count").over("division", "day")
-                ),
+                phi=(pl.col("count") / pl.sum("count").over("division", "day")),
             )
             .drop("count")
             .join(
@@ -31,3 +29,11 @@ def proportions_mae(samples, data):
         .group_by("lineage", "division", "day")
         .agg(mae=pl_mae("phi", "phi_sampled"))
     )
+
+
+def proportions_mae(
+    sample: pl.DataFrame, data: pl.DataFrame, score_column: str = "mae"
+) -> float:
+    """MAE on phi, summed over all lineages, divisions, and days"""
+
+    return proportions_mae(sample, data).collect().get_columns(score_column).sum()

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -28,6 +28,8 @@ def proportions_mae_per_division_day(samples, data) -> pl.DataFrame:
         )
         .group_by("lineage", "division", "day")
         .agg(mae=pl_mae("phi", "phi_sampled"))
+        .group_by("division", "day")
+        .agg(pl.sum("mae"))
     )
 
 


### PR DESCRIPTION
In #10 , the computation of the score is spread between `linmod.eval.mae_proportions` and `eval.py`. The function `mae_proportions()` returns a data frame that `eval.py` then needs to summarize, in order to get a final score.

Instead, the score should be a single function that takes in samples and data and returns a single score. This way, you can add in multiple scores very easily.