### PR TITLE
Added a new metric (energy score)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,26 +46,28 @@ Must-haves
 	- Regression assuming spatial independence, no time covariate
 	- Regression assuming spatial independence and a time covariate
 - [x] (2) Design simulation study to verify model implementation
-- [ ] (3) Implement a metric to evaluate population-level lineage domination time predictions in a retrospective setting
-	- Answer two questions: will lineage X take off? Given that lineage X takes off, at what time point does it reach 50% phi?
-- [ ] (4) Prepare for symposium & friends
+- [x] (3) Implement a couple metrics to evaluate population-level lineage proportion forecasts in a retrospective setting
+- [ ] (4) Conduct retrospective evaluations of our models with our metrics
+- [ ] (5) Prepare for symposium & friends
 
 Wishlist
-- [ ] (5) Can we obtain lineage growth rates in a model-agnostic way, from only posterior samples of population-level lineage proportions?
-- [ ] (6) Implement more advanced model and simulation study to verify
+- [ ] (6) Implement a metric to evaluate population-level lineage domination time predictions in a retrospective setting
+	- Answer two questions: will lineage X take off? Given that lineage X takes off, at what time point does it reach 50% phi?
+- [ ] (7) Can we obtain lineage growth rates in a model-agnostic way, from only posterior samples of population-level lineage proportions?
+- [ ] (8) Implement more advanced model and simulation study to verify
 	- Regression with information sharing over space
-- [ ] (7) Study more on how to set priors on the logit scale to induce priors on the probability simplex
-- [ ] (8) Does our ability to identify "good" models change if we evaluate daily vs weekly predictions?
+- [ ] (9) Study more on how to set priors on the logit scale to induce priors on the probability simplex
+- [ ] (10) Does our ability to identify "good" models change if we evaluate daily vs weekly predictions?
 
 | Sprint | Start Date | Target milestones | Notes                            |
 | ------ | ---------- | ----------------- | -------------------------------- |
 | L      | Jun 10     | 1                 |                                  |
 | M      | Jun 24     | 1, 2              |                                  |
 | N      | Jul 08     | 2, 3              |                                  |
-| O      | Jul 22     | 3, 4              |                                  |
-| P      | Aug 05     | 4, 5              | Thanasi at JSM for one week here |
+| O      | Jul 22     | 3                 |                                  |
+| P      | Aug 05     | 3, 4              | Thanasi at JSM for one week here |
 | Q      | Aug 19     | 4, 5              |                                  |
-| R      | Sep 2      | 6                 |                                  |
+| R      | Sep 2      |                   |                                  |
 | S      | Sep 16     |                   |                                  |
 
 

--- a/exploration/demo/evaluate.py
+++ b/exploration/demo/evaluate.py
@@ -6,9 +6,12 @@ from pathlib import Path
 
 import polars as pl
 
-from linmod.eval import proportions_mae
+from linmod.eval import proportions_energy_score, proportions_mean_norm
 
-score_functions = {"mae": proportions_mae}
+score_functions = {
+    "mean_norm": proportions_mean_norm,
+    "energy_score": proportions_energy_score,
+}
 
 
 if len(sys.argv) != 2:

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -4,7 +4,13 @@ from linmod.utils import pl_list_cycle, pl_norm
 
 
 def _merge_samples_and_data(samples, data):
-    return (
+    r"""
+    Join the forecast samples and raw data dataframes, assuming they have the
+    standard format.
+
+    Also compute the true proportions from the raw data.
+    """
+    result = (
         data.with_columns(
             phi=(
                 pl.col("count") / pl.sum("count").over("fd_offset", "division")
@@ -18,6 +24,10 @@ def _merge_samples_and_data(samples, data):
             suffix="_sampled",
         )
     )
+
+    assert result.shape == data.shape
+
+    return result
 
 
 def proportions_mean_norm_per_division_day(samples, data, p=1):
@@ -98,7 +108,10 @@ def proportions_energy_score(sample, data, p=2) -> float:
     r"""
     The energy score of proportion forecasts, summed over all divisions and days.
 
-    $\sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_p ] - \frac{1}{2} E[ || f_{tg} - \f_{tg}' ||_p ]$
+    $$
+    \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_p ]
+    - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_p ]
+    $$
     """
 
     return (

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -25,8 +25,6 @@ def _merge_samples_and_data(samples, data):
         )
     )
 
-    assert result.shape == data.shape
-
     return result
 
 

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -39,6 +39,17 @@ def proportions_mean_norm_per_division_day(samples, data, L=1):
     )
 
 
+def proportions_mean_norm(sample, data, L=1) -> float:
+    """The expected norm of phi error, summed over all divisions and days."""
+
+    return (
+        proportions_mean_norm_per_division_day(sample, data, L=L)
+        .collect()
+        .get_column("mean_norm")
+        .sum()
+    )
+
+
 def proportions_energy_score_per_division_day(samples, data):
     """
     Monte Carlo approximation to the energy score (multivariate generalization of CRPS)
@@ -76,4 +87,15 @@ def proportions_energy_score_per_division_day(samples, data):
         .agg(
             energy_score=pl.col("term1").mean() - 0.5 * pl.col("term2").mean()
         )
+    )
+
+
+def proportions_energy_score(sample, data) -> float:
+    """The energy score of phi, summed over all divisions and days."""
+
+    return (
+        proportions_energy_score_per_division_day(sample, data)
+        .collect()
+        .get_column("energy_score")
+        .sum()
     )

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -1,49 +1,79 @@
 import polars as pl
 
-from linmod.utils import pl_mae
+from linmod.utils import pl_norm
 
 
-def proportions_mae_per_division_day(samples, data) -> pl.DataFrame:
+def _merge_samples_and_data(samples, data):
+    return (
+        data.with_columns(
+            phi=(
+                pl.col("count") / pl.sum("count").over("division", "fd_offset")
+            ),
+        )
+        .drop("count")
+        .join(
+            samples,
+            on=("lineage", "division", "fd_offset"),
+            how="left",
+            suffix="_sampled",
+        )
+    )
+
+
+def proportions_mean_norm_per_division_day(samples, data, L=1):
     """
-    A simple MAE on phi for each lineage-division-day.
+    The expected norm of phi error for each division-day.
 
     `samples` should have the standard model output format.
     `data` should have the standard model input format.
 
-    Returns a DataFrame with columns `(lineage, division, fd_offset, mae)`.
+    Returns a DataFrame with columns `(division, fd_offset, mean_norm)`.
     """
 
     return (
-        (
-            data.with_columns(
-                phi=(
-                    pl.col("count")
-                    / pl.sum("count").over("division", "fd_offset")
-                ),
-            )
-            .drop("count")
-            .join(
-                samples,
-                on=("lineage", "division", "fd_offset"),
-                how="left",
-                suffix="_sampled",
-            )
-        )
-        .group_by("lineage", "division", "fd_offset")
-        .agg(mae=pl_mae("phi", "phi_sampled"))
+        _merge_samples_and_data(samples, data)
+        .group_by("sample_index", "division", "fd_offset")
+        .agg(norm=pl_norm(pl.col("phi") - pl.col("phi_sampled"), L))
         .group_by("division", "fd_offset")
-        .agg(pl.sum("mae"))
+        .agg(mean_norm=pl.mean("norm"))
     )
 
 
-def proportions_mae(
-    sample: pl.DataFrame, data: pl.DataFrame, score_column: str = "mae"
-) -> float:
-    """MAE on phi, summed over all lineages, divisions, and days"""
+def proportions_energy_score_per_division_day(samples, data):
+    """
+    Monte Carlo approximation to the energy score (multivariate generalization of CRPS)
+    of phi for each division-day.
+
+    `samples` should have the standard model output format.
+    `data` should have the standard model input format.
+
+    Returns a DataFrame with columns `(division, fd_offset, energy_score)`.
+    """
 
     return (
-        proportions_mae_per_division_day(sample, data)
-        .collect()
-        .get_column(score_column)
-        .sum()
+        _merge_samples_and_data(samples, data)
+        .with_columns(
+            # Gather the values of X' we will use for (X-X')
+            replicate=pl.col("phi_sampled")
+            .shift(1)
+            .over("fd_offset", "division", "lineage"),
+        )
+        .group_by("sample_index", "division", "fd_offset")
+        .agg(
+            term1=pl_norm(pl.col("phi") - pl.col("phi_sampled"), 2),
+            # Note that the expected value for term2 is over n-1 pairs,
+            # and the nth pair has replicate==null. However, polars will
+            # silently drop the null, resulting in term2==0 for the nth pair.
+            # To avoid this, we force term2 to null for the nth pair, so
+            # that the expected value drops the null and is taken over n-1 samples.
+            term2=pl.when(pl.col("replicate").has_nulls())
+            .then(None)
+            .otherwise(
+                pl_norm((pl.col("phi_sampled") - pl.col("replicate")), 2)
+            ),
+        )
+        .group_by("division", "fd_offset")
+        .agg(
+            energy_score=pl.col("term1").mean() - 0.5 * pl.col("term2").mean()
+        )
     )

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -1,0 +1,159 @@
+import numpy as np
+from numpy.random import default_rng
+
+from linmod import eval
+from linmod.utils import expand_grid
+
+
+def _generate_fake_samples_and_data(
+    rng,
+    num_days,
+    num_divisions,
+    num_lineages,
+    num_samples,
+    sample_variance,
+):
+    r"""
+    Generate fake data $Y_{tgl}$ and "forecasts" $phi_{tgl}$.
+
+    - $Y_{tgl} \sim Uniform{0, ..., 99}$
+    - Denote true proportion as $\pi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+    - $phi_{tgl} \sim N(\pi_{tgl}, \sigma^2)$
+    """
+
+    # Generate fake population counts
+    data = expand_grid(
+        fd_offset=range(num_days),
+        division=range(num_divisions),
+        lineage=range(num_lineages),
+    )
+
+    data = data.with_columns(count=rng.integers(0, 100, data.shape[0]))
+
+    # Generate fake forecasts of population proportions
+    samples = eval._merge_samples_and_data(
+        expand_grid(
+            fd_offset=range(num_days),
+            division=range(num_divisions),
+            lineage=range(num_lineages),
+            sample_index=range(num_samples),
+        ),
+        data,
+    ).rename({"phi": "phi_mean"})
+
+    samples = samples.with_columns(
+        phi=rng.normal(samples["phi_mean"], np.sqrt(sample_variance))
+    ).drop("phi_mean")
+
+    return samples.lazy(), data.lazy()
+
+
+def test_proportions_mean_L1_norm(
+    num_samples=100000, sample_variance=1.4, atol=0.05
+):
+    r"""
+    Test the estimate of the expected L1 norm of phi error.
+
+    The setup is as follows:
+    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
+    - Denote true proportion as $\pi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+    - Generate fake "forecasts" $phi_{tgl} \sim N(\pi_{tgl}, \sigma^2)$
+    - Check $\sum_{t, g} E[ || phi_{tg} - \pi_{tg} ||_1 ]$
+      as reported by `eval.proportions_energy_score`
+
+    Note that our "forecasts" are not actually proportions, but independent normal
+    random variables. This is so that the quantity can be computed analytically.
+    """
+
+    rng = default_rng()
+
+    NUM_DAYS = 4
+    NUM_DIVISIONS = 3
+    NUM_LINEAGES = 2
+
+    samples, data = _generate_fake_samples_and_data(
+        rng,
+        num_days=NUM_DAYS,
+        num_divisions=NUM_DIVISIONS,
+        num_lineages=NUM_LINEAGES,
+        num_samples=num_samples,
+        sample_variance=sample_variance,
+    )
+
+    # Because we use L1 norm, this metric is equal to the sum of each component's MAE
+    # from its mean.
+    # The MAE of a normal random variable from its mean is $\sigma \sqrt{2/\pi}$.
+
+    assert np.isclose(
+        eval.proportions_mean_norm(samples, data, L=1),
+        np.sqrt(sample_variance * 2 / np.pi)
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES,
+        atol=atol,
+    )
+
+
+def test_proportions_L1_energy_score(
+    num_samples=100000, sample_variance=1.4, atol=0.05
+):
+    r"""
+    Test the estimate of the energy score of phi.
+
+    The setup is as follows:
+    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
+    - Denote true proportion as $\pi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+    - Generate fake "forecasts" $phi_{tgl} \sim N(\pi_{tgl}, \sigma^2)$
+    - Check $\sum_{t, g} E[ || phi_{tg} - \pi_{tg} ||_2 ] - \frac{1}{2} E[ || phi_{tg} - \phi_{tg}' ||_2 ]$
+      as reported by `eval.proportions_energy_score`
+
+    Note that our "forecasts" are not actually proportions, but independent normal
+    random variables. This is so that the quantity can be computed analytically.
+    """
+
+    rng = default_rng()
+
+    NUM_DAYS = 4
+    NUM_DIVISIONS = 3
+    NUM_LINEAGES = 2
+
+    samples, data = _generate_fake_samples_and_data(
+        rng,
+        num_days=NUM_DAYS,
+        num_divisions=NUM_DIVISIONS,
+        num_lineages=NUM_LINEAGES,
+        num_samples=num_samples,
+        sample_variance=sample_variance,
+    )
+
+    # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
+    # its mean.
+    # The MAE of a normal random variable from its mean is $\sigma \sqrt{\frac{2}{\pi}}$.
+
+    term1 = (
+        np.sqrt(2 * sample_variance / np.pi)
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES
+    )
+
+    # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
+    # an independent copy of itself.
+    # The MAE of a normal random variable from an independent copy is $\frac{2\sigma}{\sqrt{\pi}}$.
+
+    term2 = (
+        (2 * np.sqrt(sample_variance / np.pi))
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES
+    )
+
+    assert np.isclose(
+        eval.proportions_energy_score(samples, data, L=1),
+        term1 - 0.5 * term2,
+        atol=atol,
+    )
+
+
+test_proportions_mean_L1_norm()
+test_proportions_L1_energy_score()

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -86,7 +86,9 @@ def test_proportions_mean_L1_norm(
 
     # Because we use L1 norm, this metric is equal to the sum of each component's MAE
     # from its mean.
-    # The MAE of a normal random variable from its mean is $\sigma \sqrt{2/\pi}$.
+    # The MAE of a normal random variable from its mean is $\sigma \sqrt{\frac{2}{\pi}}$
+    # (because $X - \mu \sim N(0, \sigma^2)$, so
+    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
 
     assert np.isclose(
         eval.proportions_mean_norm(samples, data, p=1),
@@ -179,8 +181,10 @@ def test_proportions_L1_energy_score(
     - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
     - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
     - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
-    - Check $\sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ] - \frac{1}{2} E[ || f_{tg} - \f_{tg}' ||_2 ]$
-      as reported by `eval.proportions_energy_score`
+    - Check $$
+        \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
+        - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
+      $$ as reported by `eval.proportions_energy_score`
 
     Note that our "forecasts" are not actually proportions, but independent normal
     random variables. This is so that the quantity can be computed analytically.
@@ -203,7 +207,9 @@ def test_proportions_L1_energy_score(
 
     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
     # its mean.
-    # The MAE of a normal random variable from its mean is $\sigma \sqrt{\frac{2}{\pi}}$.
+    # The MAE of a normal random variable from its mean is $\sigma \sqrt{\frac{2}{\pi}}$
+    # (because $X - \mu \sim N(0, \sigma^2)$, so
+    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
 
     term1 = (
         np.sqrt(2 * sample_variance / np.pi)
@@ -214,7 +220,9 @@ def test_proportions_L1_energy_score(
 
     # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
     # an independent copy of itself.
-    # The MAE of a normal random variable from an independent copy is $\frac{2\sigma}{\sqrt{\pi}}$.
+    # The MAE of a normal random variable from an independent copy is
+    # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
+    # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
 
     term2 = (
         (2 * np.sqrt(sample_variance / np.pi))

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -86,8 +86,8 @@ def test_proportions_mean_L1_norm(
 
     # Because we use L1 norm, this metric is equal to the sum of each component's MAE
     # from its mean.
-    # The MAE of a normal random variable from its mean is $\sigma \sqrt{\frac{2}{\pi}}$
-    # (because $X - \mu \sim N(0, \sigma^2)$, so
+    # The mean absolute error of a normal random variable from its mean is
+    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
 
     assert np.isclose(
@@ -207,8 +207,8 @@ def test_proportions_L1_energy_score(
 
     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
     # its mean.
-    # The MAE of a normal random variable from its mean is $\sigma \sqrt{\frac{2}{\pi}}$
-    # (because $X - \mu \sim N(0, \sigma^2)$, so
+    # The mean absolute error of a normal random variable from its mean is
+    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
 
     term1 = (
@@ -220,7 +220,7 @@ def test_proportions_L1_energy_score(
 
     # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
     # an independent copy of itself.
-    # The MAE of a normal random variable from an independent copy is
+    # The mean absolute error of a normal random variable from an independent copy is
     # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
     # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
 

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -345,9 +345,3 @@ def test_proportions_L1_energy_score2():
         check_row_order=False,
         check_column_order=True,
     )
-
-
-test_proportions_mean_L1_norm()
-test_proportions_L1_energy_score()
-test_proportions_mean_L1_norm2()
-test_proportions_L1_energy_score2()

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -89,7 +89,7 @@ def test_proportions_mean_L1_norm(
     # The MAE of a normal random variable from its mean is $\sigma \sqrt{2/\pi}$.
 
     assert np.isclose(
-        eval.proportions_mean_norm(samples, data, L=1),
+        eval.proportions_mean_norm(samples, data, p=1),
         np.sqrt(sample_variance * 2 / np.pi)
         * NUM_DAYS
         * NUM_DIVISIONS
@@ -156,7 +156,7 @@ def test_proportions_mean_L1_norm2():
     )
 
     result = eval.proportions_mean_norm_per_division_day(
-        samples, data, L=1
+        samples, data, p=1
     ).collect()
 
     assert_frame_equal(
@@ -224,7 +224,7 @@ def test_proportions_L1_energy_score(
     )
 
     assert np.isclose(
-        eval.proportions_energy_score(samples, data, L=1),
+        eval.proportions_energy_score(samples, data, p=1),
         term1 - 0.5 * term2,
         atol=atol,
     )
@@ -328,7 +328,7 @@ def test_proportions_L1_energy_score2():
     )
 
     result = eval.proportions_energy_score_per_division_day(
-        samples, data, L=1
+        samples, data, p=1
     ).collect()
 
     assert_frame_equal(

--- a/linmod/tests/test_models.py
+++ b/linmod/tests/test_models.py
@@ -1,9 +1,0 @@
-from linmod import add_one, add_two
-
-
-def test_add_one():
-    assert add_one(1) == 2
-
-
-def test_add_two():
-    assert add_two(1) == 3

--- a/linmod/utils.py
+++ b/linmod/utils.py
@@ -3,8 +3,13 @@ from functools import reduce
 import polars as pl
 
 
-# Like the R version
 def expand_grid(**columns):
+    """
+    Create a DataFrame from all combinations of given columns.
+
+    Operates like the R function `tidyr::expand_grid`.
+    """
+
     column_dfs = map(
         lambda c: pl.DataFrame(c[1], schema=[c[0]]), columns.items()
     )
@@ -14,6 +19,11 @@ def expand_grid(**columns):
 
 
 def pl_list_cycle(pl_expr, n: int):
+    """
+    Returns the column computed by `pl_expr`, but with the last `n` elements
+    moved to the front.
+    """
+
     assert n > 0
 
     return pl_expr.list.tail(n).list.concat(
@@ -21,9 +31,15 @@ def pl_list_cycle(pl_expr, n: int):
     )
 
 
-def pl_norm(pl_expr, L: int):
-    return pl_expr.abs().pow(L).sum().pow(1 / L)
+def pl_norm(pl_expr, p: int):
+    r"""
+    Computes the L_p norm $||\cdot||_p$ of the column `pl_expr`.
+    """
+    return pl_expr.abs().pow(p).sum().pow(1 / p)
 
 
 def pl_softmax(pl_expr):
+    """
+    Computes the softmax of the column `pl_expr`.
+    """
     return pl_expr.exp() / pl_expr.exp().sum()

--- a/linmod/utils.py
+++ b/linmod/utils.py
@@ -13,23 +13,9 @@ def expand_grid(**columns):
     return df.sort(columns.keys())
 
 
-def pl_crps(samples_column: str, truth_column: str):
-    """
-    Monte Carlo approximation to the CRPS.
-    """
-
-    samples = pl.col(samples_column)
-    truth = pl.col(truth_column)
-    n = samples.len()
-
-    return (samples - truth).abs().mean() - 0.5 * (
-        samples.head(n - 1) - samples.tail(n - 1)
-    ).abs().mean()
+def pl_norm(pl_expr, L: int):
+    return pl_expr.abs().pow(L).sum().pow(1 / L)
 
 
 def pl_softmax(pl_expr):
     return pl_expr.exp() / pl_expr.exp().sum()
-
-
-def pl_mae(samples_column: str, truth_column: str):
-    return (pl.col(samples_column) - pl.col(truth_column)).abs().mean()

--- a/linmod/utils.py
+++ b/linmod/utils.py
@@ -13,6 +13,14 @@ def expand_grid(**columns):
     return df.sort(columns.keys())
 
 
+def pl_list_cycle(pl_expr, n: int):
+    assert n > 0
+
+    return pl_expr.list.tail(n).list.concat(
+        pl_expr.list.head(pl_expr.list.len() - n)
+    )
+
+
 def pl_norm(pl_expr, L: int):
     return pl_expr.abs().pow(L).sum().pow(1 / L)
 


### PR DESCRIPTION
What's new:

- A new metric: energy score, which is a multivariate generalization of CRPS
- `proportions_mae` is now `proportions_mean_norm`, to be a bit more correct in our naming
  - Correct me if I'm misremembering, but "mean absolute error" is defined on scalars, not vectors, and we were summing the MAE over lineages to resolve this. This is equivalent to taking the "mean L1 norm of the error", so I use that name now
- I realized quickly that joining samples and data was going to happen in every metric function, so that is its own function now