### PR TITLE
Automatic path creation

### DIFF
--- a/linmod/data.py
+++ b/linmod/data.py
@@ -25,7 +25,6 @@ from human hosts are included.
 import lzma
 import sys
 from datetime import datetime
-from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -34,7 +33,7 @@ import polars as pl
 import yaml
 import zstandard
 
-from .utils import print_message
+from .utils import ValidPath, print_message
 
 DEFAULT_CONFIG = {
     "data": {
@@ -144,15 +143,13 @@ def main(cfg: Optional[dict]):
 
     parsed_url = urlparse(config["data"]["source"])
     cache_path = (
-        Path(config["data"]["cache_dir"])
+        ValidPath(config["data"]["cache_dir"])
         / parsed_url.netloc
         / parsed_url.path.lstrip("/").rsplit(".", 1)[0]
     )
 
     if config["data"]["redownload"] or not cache_path.exists():
         print_message("Downloading...", end="")
-
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
 
         with urlopen(config["data"]["source"]) as response, cache_path.open(
             "wb"
@@ -238,11 +235,7 @@ def main(cfg: Optional[dict]):
         .collect()
     )
 
-    Path(config["data"]["save_file"]["eval"]).parent.mkdir(
-        parents=True, exist_ok=True
-    )
-
-    eval_df.write_csv(config["data"]["save_file"]["eval"])
+    eval_df.write_csv(ValidPath(config["data"]["save_file"]["eval"]))
 
     print_message(" done.")
     print_message("Exporting modeling dataset...", end="")
@@ -258,11 +251,7 @@ def main(cfg: Optional[dict]):
         .collect()
     )
 
-    Path(config["data"]["save_file"]["model"]).parent.mkdir(
-        parents=True, exist_ok=True
-    )
-
-    model_df.write_csv(config["data"]["save_file"]["model"])
+    model_df.write_csv(ValidPath(config["data"]["save_file"]["model"]))
 
     print_message(" done.")
 

--- a/linmod/utils.py
+++ b/linmod/utils.py
@@ -1,7 +1,25 @@
 import sys
 from functools import reduce
+from pathlib import Path
 
 import polars as pl
+
+
+class ValidPath(Path):
+    """
+    Functions like `pathlib.Path`, but ensures that the path exists.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.is_dir():
+            self.mkdir(parents=True, exist_ok=True)
+        else:
+            self.parent.mkdir(parents=True, exist_ok=True)
+
+    def __truediv__(self, child):
+        return ValidPath(super().__truediv__(child))
 
 
 def expand_grid(**columns):

--- a/present-day-forecasting/config.yaml
+++ b/present-day-forecasting/config.yaml
@@ -1,8 +1,8 @@
 data:
   # Where are the processed datasets for modeling and evaluation stored?
   save_file:
-    model: data/metadata-model.csv
-    eval: data/metadata-eval.csv
+    model: data/model.csv
+    eval: data/eval.csv
 
   # What is the forecast date?
   # No sequences collected or reported after this date are included in the
@@ -22,7 +22,7 @@ data:
 
 forecasting:
   # Where (directory) should model output be stored?
-  save_dir: out/
+  save_dir: out/forecasts/
 
   # Which models should be fit?
   models:
@@ -50,7 +50,7 @@ forecasting:
 
 evaluation:
   # Where (file) should model scores be stored?
-  save_file: results.csv
+  save_file: out/eval/results.csv
 
   # How should forecasts be evaluated?
   metrics:

--- a/present-day-forecasting/main.py
+++ b/present-day-forecasting/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-from pathlib import Path
 
 import jax
 import numpy as np
@@ -13,7 +12,7 @@ from numpyro.infer import MCMC, NUTS
 import linmod.data
 import linmod.eval
 import linmod.models
-from linmod.utils import print_message
+from linmod.utils import ValidPath, print_message
 from linmod.visualize import plot_forecast
 
 numpyro.set_host_device_count(4)
@@ -37,8 +36,7 @@ data = pl.read_csv(config["data"]["save_file"]["model"], try_parse_dates=True)
 
 # Fit each model
 
-forecast_dir = Path(config["forecasting"]["save_dir"])
-forecast_dir.mkdir(exist_ok=True)
+forecast_dir = ValidPath(config["forecasting"]["save_dir"])
 
 for model_name in config["forecasting"]["models"]:
     forecast_path = forecast_dir / f"forecasts_{model_name}.csv"
@@ -87,7 +85,6 @@ for model_name in config["forecasting"]["models"]:
         and convergence.shape[0] > 0
     ):
         plot_dir = forecast_dir / ("convergence_" + model_name)
-        plot_dir.mkdir(exist_ok=True)
         plots = linmod.models.plot_convergence(mcmc, convergence["param"])
         for plot, par in zip(plots, convergence["param"].to_list()):
             plot.save(plot_dir / (par + ".png"), verbose=False)
@@ -142,4 +139,4 @@ pl.DataFrame(
     scores,
     schema=["Metric", "Model", "Score"],
     orient="row",
-).write_csv(config["evaluation"]["save_file"])
+).write_csv(ValidPath(config["evaluation"]["save_file"]))


### PR DESCRIPTION
_If this is over-engineered, then I'm not particularly attached to it, but let's see what we think._


We have a lot of `Path.mkdir` sprinkled throughout the code, which makes sense, as we create a lot of exports in a nested file hierarchy. However, I've been bit a couple times now by forgetting or misconfiguring a `mkdir`, and I'd like to help us avoid future bugs.

What I've done is wrapped around the `Path` class to give us `ValidPath`, which essentially guarantees the existence of whichever directory you're trying to write to. (This is especially helpful when nesting downwards, since `class(ValidPath(".") / "child") == ValidPath`.)

For example, from our codebase,

```python
Path(config["data"]["save_file"]["eval"]).parent.mkdir(
    parents=True, exist_ok=True
)

eval_df.write_csv(config["data"]["save_file"]["eval"])
```

becomes

```python
eval_df.write_csv(ValidPath(config["data"]["save_file"]["eval"]))
```

and

```python
forecast_dir = Path(config["forecasting"]["save_dir"])
forecast_dir.mkdir(exist_ok=True)

# ...

plot_dir = forecast_dir / ("convergence_" + model_name)
plot_dir.mkdir(exist_ok=True)

plot.save(plot_dir / (par + ".png"), verbose=False)
```

becomes

```python
forecast_dir = ValidPath(config["forecasting"]["save_dir"])

# ...

plot.save(
    forecast_dir / ("convergence_" + model_name) / (par + ".png"),
    verbose=False
)
```