### PR TITLE
Prior selection

### DIFF
--- a/exploration/priors.qmd
+++ b/exploration/priors.qmd
@@ -1,0 +1,294 @@
+---
+title: "Prior choices"
+format:
+  html:
+    code-fold: true
+    embed-resources: true
+jupyter: python3
+---
+
+First, some imports, RNG keys, and global settings.
+```{python}
+import jax
+import matplotlib.pyplot as plt
+import numpy
+import numpy.random
+import numpyro
+import numpyro.util
+import numpyro.distributions as dist
+import jax.numpy as jnp
+
+from jax.nn import softmax
+
+
+num_samples = int(1e4)
+num_lineages = 10
+```
+
+Some visualization shortcut code.
+```{python}
+def viz_one_lineage(imat, bins=100):
+    fig, ax = plt.subplots()
+    ax.hist(imat[:,0], bins=bins)
+    plt.show()
+
+def viz_lineage_change(imat, which, bins=100):
+    assert isinstance(which, int)
+    if which >= 0 and which < imat[0].shape[1]:
+        toplot = jnp.array((imat[0, :, which], imat[1, :, which]))
+    else:
+        toplot = jnp.array((jnp.max(imat[0], axis=1), jnp.max(imat[1], axis=1)))
+    fig, axs = plt.subplots(1, 2, sharey=True, tight_layout=True)
+    axs[0].hist(toplot[0], bins=bins)
+    axs[1].hist(toplot[1], bins=bins)
+    plt.show()
+
+def viz_lineage_change_biv(imat, which, bins=100):
+    assert isinstance(which, int)
+    if which >= 0 and which < imat[0].shape[1]:
+        toplot = jnp.array((imat[0, :, which], imat[1, :, which]))
+    else:
+        toplot = jnp.array((jnp.max(imat[0], axis=1), jnp.max(imat[1], axis=1)))
+    fig, ax = plt.subplots(tight_layout=True)
+    ax.hist2d(toplot[0], toplot[1], bins=bins)
+    plt.show()
+
+def viz_lineage_change_delta(imat, which, bins=100):
+    assert isinstance(which, int)
+    if which >= 0 and which < imat[0].shape[1]:
+        toplot = jnp.array((imat[0, :, which], imat[1, :, which]))
+    else:
+        toplot = jnp.array((jnp.max(imat[0], axis=1), jnp.max(imat[1], axis=1)))
+    fig, ax = plt.subplots(tight_layout=True)
+    ax.hist(toplot[1] - toplot[0], bins=bins)
+    plt.show()
+```
+
+## Baseline model
+The baseline model is that all lineage proportions are constant in each state, and that states are independent.
+Thus we can focus on a single state, within which proportions for each lineage $\phi_{\ell}$ are drawn independently and identically (IID) as follows,
+\begin{align*}
+  &\zeta_{\ell} \sim \text{Normal}(0, 1)\\
+  &\phi_{\ell} := \frac{e^{-\zeta_{\ell}}}{\sum_k e^{-\zeta_{k}}}
+\end{align*}
+
+The following plots (of the marginal distribution of the intercept for a single lineage) show that this compares not unfavorably to a flat Dirichlet, at least in the realm of dimensions we're considering.
+
+```{python}
+def simulate_ints_base_logit(nobs, nlin, seed):
+    with numpyro.handlers.seed(rng_seed=seed):
+        logit_phi = numpyro.sample("logit_phi", dist.Normal(0, 1), sample_shape=(nobs, nlin,))
+        prop_ints = jnp.apply_along_axis(
+            lambda lp: softmax(lp),
+            1,
+            logit_phi
+        )
+
+    return prop_ints
+
+viz_one_lineage(simulate_ints_base_logit(num_samples, num_lineages, 42), bins=100)
+```
+
+```{python}
+def simulate_ints_base_dirichlet(nobs, nlin, alpha, seed):
+    with numpyro.handlers.seed(rng_seed=seed):
+        prop_ints = numpyro.sample("phi", dist.Dirichlet(jnp.array([alpha] * nlin)), sample_shape=(nobs,))
+
+    return prop_ints
+
+viz_one_lineage(simulate_ints_base_dirichlet(num_samples, num_lineages, 1, 42), bins=100)
+```
+
+## Independent divisions model
+The independent divisions model builds off the baseline model by allowing for growth of lineages over time, independently in each division.
+Focusing in on one division, we now have logit-scale intercepts $\beta_{0 \ell}$ and logit-scale growth rates $\beta_{1 \ell}$.
+The proportion of a lineage at time $t$ is given by the model,
+\begin{align*}
+  &\beta_{0 \ell} \sim \text{Normal}(0, 1)\\
+  &\beta_{1 \ell} \sim \text{Normal}(0, 0.1^2)\\
+  &\phi_{t \ell} := \frac{e^{-(\beta_{0 \ell} + t \beta_{1 \ell})}}{\sum_k e^{-(\beta_{0 \ell} + t \beta_{1 \ell})}}
+\end{align*}
+
+As we have already established that the intercept prior is reasonable, let us investigate what the effect is of our ``slope'' distribution.
+Setting a reasonable prior value here is somewhat difficult, as our intuition about what is reasonable is mostly confined to the extreme event when a new, highly-fit lineage arrives and takes off.
+We are thus inherently reasoning about the tails of the distribution, in particular the distribution of a sample maximum (the maximum slope parameter).
+
+In these tails, our intuition suggests that the order of time for something rare and highly-fit to go from $\approx 0$ to its maximum (which in these models will always be 1 eventually) should be on the order of months.
+It should certainly not be able to take over in a week or less.
+
+```{python}
+# The last lineage starts at frequency "low" and has the largest-drawn fitness
+# The first lineage starts at frequency "high," the rest start at intermediate fitness
+def simulate_takeover_ind_div(nobs, nlin, low, high, duration, slope_scale, seed):
+    assert nlin > 2
+    rest = (1.0 - low - high) / (nlin - 2)
+    nonlow = [rest] * (nlin - 2)
+    nonlow.append(high)
+    # Ensure the rarest lineage has the highest fitness
+    with numpyro.handlers.seed(rng_seed=seed):
+        beta_0_list = []
+        for _ in range(nobs):
+            tmp = nonlow.copy()
+            numpy.random.shuffle(nonlow)
+            tmp.append(low)
+            beta_0_list.append(numpy.log(tmp))
+
+        beta_0 = jnp.array(beta_0_list)
+
+        beta_1 = numpyro.sample("slopes", dist.Normal(0, slope_scale), sample_shape=(nobs, nlin,)).sort(axis=1)
+
+        props_init = jnp.apply_along_axis(
+            lambda lp: softmax(lp),
+            1,
+            beta_0
+        )
+
+        props_final = jnp.apply_along_axis(
+            lambda lp: softmax(lp),
+            1,
+            beta_0 + duration * beta_1
+        )
+
+    return jnp.array((props_init, props_final))
+```
+
+
+```{python}
+slope_scale = 0.25
+id_sim = simulate_takeover_ind_div(num_samples, num_lineages, 0.01, 0.8, 7, slope_scale, 42)
+viz_lineage_change_delta(id_sim, which=9)
+```
+
+```{python}
+id_sim = simulate_takeover_ind_div(num_samples, num_lineages, 0.01, 0.8, 30, slope_scale, 42)
+viz_lineage_change_delta(id_sim, which=9)
+```
+
+```{python}
+id_sim = simulate_takeover_ind_div(num_samples, num_lineages, 0.01, 0.8, 91, slope_scale, 42)
+viz_lineage_change_delta(id_sim, which=9)
+```
+
+```{python}
+(id_sim[1, :, 9] - id_sim[0, :, 9] < 0.5).mean()
+```
+
+This also seems plausible.
+The fittest lineage, starting rare, won't take over in a week of a month, but it might in 3.
+This is good because we want a model that can apply to 2022 ($\approx 4$ sweeps) or 2023 (which had protracted periods where nothing was sweeping rapidly).
+
+## Hierarchical divisions model
+The hierarchical divisions model pools information across locations.
+This is accomplished separately and distinctly for the intercepts and slopes.
+
+### Intercept
+
+The slopes are modeled with a shared mean vector $\boldsymbol{\mu}_{\beta_0}$, describing the per-lineage median proportion (logit-scale mean), a per-lineage variability term $\boldsymbol{\sigma}_{\beta_0}$, describing how much particular lineage starting proportions vary, and finally a per-lineage, per-division uncentered error/noise/deviation term $\mathbf{Z}_0$, with $Z_{\beta_0 g \ell}$ the deviation in location $g$ for lineage $\ell$.
+The model for the intercept of lineage $\ell$ in location $g$, $\beta_{0 g \ell}$ is then,
+\begin{align*}
+  &\mu_{\beta_0 \ell} \sim \text{Normal}(0, \sqrt{2}^2)\\
+  &\sigma_{\beta_0 \ell} \sim \text{Exponential}(1)\\
+  &z_{\beta_0 g \ell} \sim \text{Normal}(0, \sqrt{2}^2)\\
+  &\beta_{0 g \ell} := \mu_{\beta_0 \ell} + \sigma_{\beta_0 \ell} * z_{\beta_0 g \ell}
+\end{align*}
+
+Taking advantage of the fact that all means are 0, variance of the $\beta_{0 g \ell}$ [is thus](https://en.wikipedia.org/wiki/Distribution_of_the_product_of_two_random_variables#Variance_of_the_product_of_independent_random_variables) $\text{Var}[\mu_{\beta_0 \ell}] + \text{Var}[\sigma_{\beta_0 \ell}]\text{Var}[z_{\beta_0 g \ell}]$.
+
+The distributions above with their chosen parameters keep the $\text{Var}[\beta_{0 g \ell}] = 1$ for consistency with the other models.
+The exact choice of distributions is somewhat arbitrary, the main factor is that the hierarchical variance parameter should have a mode at 0, in order to exert regularization towards shared proportions.
+Some arbitrariness comes from the choice of distributions, more comes from the relative allocation of the total variance to the components.
+
+As we can see below, the resulting marginal prior is not absurd.
+
+```{python}
+def simulate_ints_hier(nobs, nlin, seed):
+    with numpyro.handlers.seed(rng_seed=seed):
+        mu_beta_0 = numpyro.sample(
+            "mu_beta_0",
+            dist.Normal(0, 0.70710678),
+            sample_shape=(nlin, nobs,),
+        )
+        sigma_beta_0 = numpyro.sample(
+            "sigma_beta_0",
+            dist.Exponential(1.0),
+            sample_shape=(nlin, nobs,),
+        )
+        z_0 = numpyro.sample(
+            "z_0",
+            dist.Normal(0, 0.70710678),
+            sample_shape=(nlin, nobs,),
+        )
+        beta_0 = numpyro.deterministic(
+            "beta_0",
+            mu_beta_0 + sigma_beta_0 * z_0,
+        ).T
+
+        prop_ints = jnp.apply_along_axis(
+            lambda lp: softmax(lp),
+            1,
+            beta_0
+        )
+
+    return prop_ints
+
+viz_one_lineage(simulate_ints_hier(num_samples, num_lineages, 42), bins=100)
+
+```
+
+### Slope
+Information on slopes is shared by giving each location a slope drawn from a shared distribution.
+That distribution is specifically Multivariate Normal with mean vector $\boldsymbol{\mu}_{\beta_1}$ and covariance matrix $\Sigma$.
+When $\Sigma$ is not the identity matrix, shared deviations are possible, which may capture unmodeled factors such as immune history that would make some set of lineages collectively more or less fit in a particular location.
+The prior on $\Sigma$ is decomposed into a prior on the diagonals and an LKJ prior on the strength of correlation.
+
+Put together, slopes are modeled as follows,
+\begin{align*}
+  &\mu_{\beta_1 \ell} \sim \text{Normal}(0, \xi^2)\\
+  &\boldsymbol{\Omega} \sim \text{LKJ}(2)\\
+  &\sigma_{\beta_1 \ell} \sim \text{Exponential}(\lambda)\\
+  &\boldsymbol{\Sigma} := \sqrt{\operatorname{diag}(\boldsymbol{\sigma})} \boldsymbol{\Omega} \sqrt{\operatorname{diag}(\boldsymbol{\sigma})}\\
+  &\beta_{1 g} \sim \text{MVN}(\mu_{\beta_1}, \boldsymbol{\Sigma})
+\end{align*}
+Where $\operatorname{diag}$ makes the corresponding diagonal matrix (0 elsewhere, diagonal equal to the specified vector).
+
+The marginal distribution on $\beta_{1 g \ell}$ has variance $\text{Var}[\beta_{1 g \ell}] = \xi^2 + \sigma_{\beta_1 \ell}^2$.
+The strength of pooling is then determined by the relative allocation of the variance between the shared component ($\xi$) and the unshared component ($\sigma_{\beta_1 \ell}$).
+Assuming that we have a desired target marginal variance (whether that is the above 1/16 or not), we should choose the prior variances of each component such that they sum to that.
+Lacking a better sense of what this should be, and keeping the above 1/16 as the target variance, I propose to us $\lambda = \sqrt{32}$ and $\xi = 1 / \sqrt{32}$.
+This makes the _expectation_ comparable to the variance in the independent divisions model.
+But it should be noted that in practice the model appears to regularly pull the variance higher, sometime much, much higher.
+This violates our principle above of how fast we think variants should be allowed to take over.
+
+### Model changes to consider
+
+#### Adaptive pooling strength
+The strength of pooling in our model is currently fixed by the variances implied by our chosen prior distributions and hyperparameters.
+Broadly, in this framework, instead of putting fixed hyperparameters directly on pooled parameters and error terms, we choose a marginal variance hyperparameter and a strength of pooling parameter which allocates that among the two components.
+
+This is a bit easier to envision with the slope model than the intercept (and likely more important there anyways):
+\begin{align*}
+  &\sigma^2_{\beta_0 \text{marg}} = \frac{1}{16}\\
+  &\rho \sim \text{Beta}(\alpha, \beta)\\
+  &\mu_{\beta_1 \ell} \sim \text{Normal}(0, \rho \sigma^2_{\beta_0 \text{marg}})\\
+  &\boldsymbol{\Omega} \sim \text{LKJ}(2)\\
+  &\sigma_{\beta_1 \ell} \sim \text{Exponential}(1 / \sqrt{(1 - \rho) \sigma^2_{\beta_0 \text{marg}}})\\
+  &\boldsymbol{\Sigma} := \sqrt{\operatorname{diag}(\boldsymbol{\sigma})} \boldsymbol{\Omega} \sqrt{\operatorname{diag}(\boldsymbol{\sigma})}\\
+  &\beta_{1 g} \sim \text{MVN}(\mu_{\beta_1}, \boldsymbol{\Sigma})
+\end{align*}
+
+Here, the larger $\rho$ is, the stronger the pooling is.
+At the extreme of $\rho = 1$, $\sigma_{\beta_1 \ell} = 0$ and all locations have exactly the shared slope.
+At the opposite extreme of $\rho = 0$, all variation is per-location per-lineage.
+
+
+#### LKJ tweaks
+We are currently fixing the strength of correlation _a priori_, but we could conceive of letting the model figure it out.
+We would simply replace
+\[
+  \boldsymbol{\Omega} \sim \text{LKJ}(2)
+\]
+with
+\[
+  \boldsymbol{\Omega} \sim \text{LKJ}(\eta)
+  \eta \sim \text{Pr}(\eta).
+\]

--- a/exploration/whole_hist_viz.py
+++ b/exploration/whole_hist_viz.py
@@ -1,14 +1,21 @@
 import argparse
 import datetime
 
+import numpyro.distributions as dist
 import polars as pl
-from plotnine import aes, geom_line, ggplot, theme_bw
+from plotnine import aes, geom_line, geom_ribbon, ggplot, theme_bw
 
 
-def make_plot(dfp, ignore_under, first_date, last_date):
+def get_plot_data(
+    dfp, first_date, last_date, observed_only, divisions, ci_alpha
+):
     r"""
-    Plots all NextStrain clades in the available data, weekly, for the full duration.
+    Compresses history in range to US-aggregate by week.
     """
+    if ci_alpha is None:
+        z = 0.0
+    else:
+        z = float(dist.Normal(0, 1).icdf(1.0 - ci_alpha))
 
     lineage_year = (
         pl.col("lineage")
@@ -17,6 +24,10 @@ def make_plot(dfp, ignore_under, first_date, last_date):
         .str.to_integer(strict=True)
         .add(2000)
     )
+
+    last_samp_date = datetime.date(3000, 1, 1)
+    if observed_only:
+        last_samp_date = last_date
 
     df = (
         pl.scan_csv(dfp, separator="\t")
@@ -31,6 +42,8 @@ def make_plot(dfp, ignore_under, first_date, last_date):
             # Keep only samples in range of specified days
             pl.col("date") >= first_date,
             pl.col("date") <= last_date,
+            # If specified, keep only samples seen by last date
+            pl.col("date_submitted") <= last_samp_date,
             # Drop impossible lineage assigments
             # (lineages which had not yet been named, e.g. a sequence
             # in 2020 cannot belong to 23D)
@@ -38,7 +51,12 @@ def make_plot(dfp, ignore_under, first_date, last_date):
             country="USA",
             host="Homo sapiens",
         )
+        .collect()
     )
+
+    if divisions is not None:
+        assert all(div in df["division"] for div in divisions)
+        df = df.filter(pl.col("division").is_in(divisions))
 
     df = (
         df.with_columns(wd=pl.col("date").dt.weekday())
@@ -54,8 +72,36 @@ def make_plot(dfp, ignore_under, first_date, last_date):
         .with_columns(
             frequency=(pl.col("count") / pl.sum("count").over("date")),
         )
-        .select("date", "lineage", "frequency")
-        .collect()
+        .with_columns(
+            ci_width=(
+                z
+                / pl.col("count").sqrt()
+                * pl.col("frequency").sqrt()
+                * (1.0 - pl.col("frequency")).sqrt()
+            )
+        )
+        .with_columns(upper_ci=(pl.col("frequency") + pl.col("ci_width")))
+        .with_columns(lower_ci=(pl.col("frequency") - pl.col("ci_width")))
+        .select("date", "lineage", "frequency", "lower_ci", "upper_ci")
+    )
+
+    return df
+
+
+def make_plot(
+    dfp,
+    ignore_under,
+    first_date,
+    last_date,
+    observed_only,
+    divisions,
+    ci_alpha,
+):
+    r"""
+    Plots all NextStrain clades in the available data, weekly, for the full duration.
+    """
+    df = get_plot_data(
+        dfp, first_date, last_date, observed_only, divisions, ci_alpha
     )
 
     trivial = (
@@ -80,6 +126,17 @@ def make_plot(dfp, ignore_under, first_date, last_date):
         + theme_bw()
     )
 
+    if ci_alpha is not None:
+        plt = plt + geom_ribbon(
+            aes(
+                x="date",
+                ymin="lower_ci",
+                ymax="upper_ci",
+                fill="lineage",
+            ),
+            alpha=0.15,
+        )
+
     return plt
 
 
@@ -102,10 +159,27 @@ if __name__ == "__main__":
         help="Plot will only include data for up to this day or earlier. Default corresponds to all days.",
     )
     parser.add_argument(
+        "-d",
+        "--division",
+        default=None,
+        help="Plot will only include data for these divisions. Default corresponds to all divisions.",
+    )
+    parser.add_argument(
         "-c",
         "--frequency_cutoff",
         default=0.5,
         help="Plot will only include lineages which exceed this frequency in at least one week",
+    )
+    parser.add_argument(
+        "-u",
+        "--uncertainty_alpha",
+        default=None,
+        help="If specified, plot will include weekly uncertainty in proportion via Wald intervals at this alpha.",
+    )
+    parser.add_argument(
+        "--observed_only",
+        action="store_true",
+        help="Controls whether only sequences observed before the sampling date are visualized.",
     )
     parser.add_argument(
         "-w", "--width", default=6, help="Plot width, in inches."
@@ -116,11 +190,18 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    divisions = None
+    if args.division is not None:
+        divisions = args.division.strip().split(",")
+
     plt = make_plot(
         args.data_filename,
         ignore_under=float(args.frequency_cutoff),
         first_date=datetime.datetime.strptime(args.first_date, "%Y-%m-%d"),
         last_date=datetime.datetime.strptime(args.last_date, "%Y-%m-%d"),
+        observed_only=args.observed_only,
+        divisions=divisions,
+        ci_alpha=float(args.uncertainty_alpha),
     )
 
     plt.save(

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -74,17 +74,17 @@ class HierarchicalDivisionsModel:
         # beta_0[g, l] is the intercept for lineage l in division g
         mu_beta_0 = numpyro.sample(
             "mu_beta_0",
-            dist.StudentT(3, -5, 5),
+            dist.Normal(0, 0.70710678),
             sample_shape=(self.num_lineages,),
         )
         sigma_beta_0 = numpyro.sample(
             "sigma_beta_0",
-            dist.TruncatedNormal(2, 1, low=0),
+            dist.Exponential(1.0),
             sample_shape=(self.num_lineages,),
         )
         z_0 = numpyro.sample(
             "z_0",
-            dist.StudentT(2),
+            dist.Normal(0, 0.70710678),
             sample_shape=(self.num_divisions, self.num_lineages),
         )
         beta_0 = numpyro.deterministic(
@@ -93,28 +93,16 @@ class HierarchicalDivisionsModel:
         )
 
         # mu_beta_1[l] is the mean of the slope for lineage l
-        mu_hierarchical = numpyro.sample(
-            "mu_hierarchical",
-            dist.Normal(-1, np.sqrt(0.5)),
-        )
-        sigma_hierarchical = numpyro.sample(
-            "sigma_hierarchical",
-            dist.TruncatedNormal(1, np.sqrt(0.1), low=0),
-        )
-        z_mu = numpyro.sample(
-            "z_mu",
-            dist.Normal(0, 1),
-            sample_shape=(self.num_lineages,),
-        )
-        mu_beta_1 = numpyro.deterministic(
+        mu_beta_1 = numpyro.sample(
             "mu_beta_1",
-            mu_hierarchical + sigma_hierarchical * z_mu,
+            dist.Normal(0, 0.1767767),
+            sample_shape=(self.num_lineages,),
         )
 
         # beta_1[g, l] is the slope for lineage l in division g
         sigma_beta_1 = numpyro.sample(
             "sigma_beta_1",
-            dist.TruncatedNormal(0.5, 2, low=0),
+            dist.Exponential(5.65685425),
             sample_shape=(self.num_lineages,),
         )
         Omega_decomposition = numpyro.sample(
@@ -245,7 +233,7 @@ class IndependentDivisionsModel:
                 beta_0 = numpyro.sample("beta_0", dist.Normal(0, 1))
 
                 # beta_1[g, l] is the slope for lineage l in division g
-                beta_1 = numpyro.sample("beta_1", dist.Normal(0, 1))
+                beta_1 = numpyro.sample("beta_1", dist.Normal(0, 0.25))
 
         likelihood = multinomial_likelihood(
             beta_0, beta_1, self.divisions, self.time, self.N

--- a/linmod/visualize.py
+++ b/linmod/visualize.py
@@ -3,21 +3,46 @@ from plotnine import (
     aes,
     facet_wrap,
     geom_line,
+    geom_point,
     geom_ribbon,
     ggplot,
+    scale_size,
     theme_bw,
     ylab,
 )
 
 
-def plot_forecast(forecast):
+def plot_forecast(forecast, counts=None):
     summaries = forecast.group_by("division", "fd_offset", "lineage").agg(
         mean_phi=pl.mean("phi"),
         q_lower=pl.quantile("phi", 0.1),
         q_upper=pl.quantile("phi", 0.9),
     )
 
-    return (
+    if counts is not None:
+        day_counts = (
+            counts.group_by(pl.col("fd_offset"), pl.col("division"))
+            .agg(pl.col("count").sum().alias("n_obs"))
+            .select("fd_offset", "division", "n_obs")
+        )
+        counts = counts.with_columns(
+            f=(
+                pl.col("count") / pl.sum("count").over("fd_offset", "division")
+            ),
+        ).join(
+            day_counts,
+            on=("fd_offset", "division"),
+            how="left",
+            validate="m:1",
+        )
+        summaries = summaries.join(
+            counts,
+            on=("fd_offset", "division", "lineage"),
+            how="left",
+            validate="1:1",
+        )
+
+    plot = (
         ggplot(summaries)
         + geom_ribbon(
             aes(
@@ -37,3 +62,23 @@ def plot_forecast(forecast):
         + theme_bw(base_size=20)
         + ylab("phi")
     )
+    if counts is not None:
+        plot = (
+            plot
+            + geom_point(
+                aes(
+                    "fd_offset",
+                    y="f",
+                    color="lineage",
+                    fill="lineage",
+                    size="count",
+                ),
+                alpha=0.5,
+                shape="o",
+            )
+            + scale_size(
+                range=(0.1, 3),
+            )
+        )
+
+    return plot

--- a/present-day-forecasting/config.yaml
+++ b/present-day-forecasting/config.yaml
@@ -48,7 +48,18 @@ forecasting:
       # Parameters containing fixed quantities have no variability and cause 0/0 errors
       ignore_nan_in: ["Omega_decomposition"]
 
+  # Visualization options
+  viz:
+    plot_data: True
+
+
+
 evaluation:
+  # Visualization options
+  viz:
+    save_dir: out/
+    plot: True
+
   # Where (file) should model scores be stored?
   save_file: out/eval/results.csv
 

--- a/present-day-forecasting/config.yaml
+++ b/present-day-forecasting/config.yaml
@@ -21,7 +21,7 @@ data:
     upper: 14
 
 forecasting:
-  # Where (directory) should model output be stored?
+  # Where (directory) should model output and visualizations be stored?
   save_dir: out/forecasts/
 
   # Which models should be fit?
@@ -48,20 +48,9 @@ forecasting:
       # Parameters containing fixed quantities have no variability and cause 0/0 errors
       ignore_nan_in: ["Omega_decomposition"]
 
-  # Visualization options
-  viz:
-    plot_data: True
-
-
-
 evaluation:
-  # Visualization options
-  viz:
-    save_dir: out/
-    plot: True
-
-  # Where (file) should model scores be stored?
-  save_file: out/eval/results.csv
+  # Where (directory) should model scores and visualizations be stored?
+  save_dir: out/eval/
 
   # How should forecasts be evaluated?
   metrics:

--- a/present-day-forecasting/main.py
+++ b/present-day-forecasting/main.py
@@ -118,7 +118,7 @@ for model_name in config["forecasting"]["models"]:
     )
 
     if config["evaluation"]["viz"]["plot"]:
-        eval_viz_dir = Path(config["evaluation"]["viz"]["save_dir"])
+        eval_viz_dir = ValidPath(config["evaluation"]["viz"]["save_dir"])
         viz_data = (
             pl.read_csv(
                 config["data"]["save_file"]["eval"], try_parse_dates=True

--- a/present-day-forecasting/main.py
+++ b/present-day-forecasting/main.py
@@ -112,6 +112,9 @@ for model_name in config["forecasting"]["models"]:
         limitsize=False,
     )
 
+    # Try to free up some memory
+    del model, mcmc, convergence, plots, plot, forecast
+
     print_message("Done.")
 
 # Load the full evaluation dataset
@@ -121,7 +124,7 @@ eval_data = pl.read_csv(
 )
 
 viz_data = eval_data.filter(
-    pl.col("lineage").is_in(model.lineage_names),
+    pl.col("lineage").is_in(model_data["lineage"].unique()),
     pl.col("fd_offset") > 0,
 )
 

--- a/present-day-forecasting/main.py
+++ b/present-day-forecasting/main.py
@@ -94,6 +94,9 @@ for model_name in config["forecasting"]["models"]:
         for plot, par in zip(plots, convergence["param"].to_list()):
             plot.save(plot_dir / (par + ".png"), verbose=False)
 
+        # Try to free up some memory
+        del plots, plot
+
     forecast = model.create_forecasts(
         mcmc,
         np.arange(
@@ -113,7 +116,7 @@ for model_name in config["forecasting"]["models"]:
     )
 
     # Try to free up some memory
-    del model, mcmc, convergence, plots, plot, forecast
+    del model, mcmc, convergence, forecast
 
     print_message("Done.")
 
@@ -151,7 +154,7 @@ for metric_name in config["evaluation"]["metrics"]:
             )
         )
 
-        plot_forecast(forecast, viz_data).save(
+        plot_forecast(forecast.collect(), viz_data).save(
             eval_dir / "visualizations" / f"eval_{model_name}.png",
             width=40,
             height=30,


### PR DESCRIPTION
This PR has suffered some scope creep, but the primary purpose is to check the priors on the models.

## Priors
Priors were out of sync with changes made to the model structure, thus some examination is necessary. I don't think this is the end-all be-all of prior selection, but I do think it is an improvement.

Importantly, the more drastic MCMC convergence problems appear to have been banished. At default run settings, convergence isn't quite what we might like for production, but I'm not seeing any truly worrisome ESS values in the dozens (low values now seem more like 200), or PSRF values near 2 (high values now are more like 1.02).

The file `exploration/priors.qmd` contains explorations of what the current priors imply.

### BaselineModel
No changes.

### IndependentDivisionsModel
I have tightened the variance on the slope prior. The original Normal(0,1 allowed for a variant starting at 1% to hit ~100% in 1 week. The current Normal(0,0.25^2) prior forbids one-week takeovers, though does allow one-month takeovers. 

#### Future note
A Normal(0, 0.1^2) would forbid one-month takeovers, which seems reasonable to me. However, this choice appears to significantly hamper model performance even with large amounts of data. This could be deserved (that is, the model is missing some other factor) or undeserved. We can pursue this when we work more seriously on model development.

### HierarchicalDivisionsModel

#### Intercepts
I have changed the intercept prior drastically in order to maintain some semblance of parity with the non-hierarchical model. By "parity" I mean "the marginal distributions on the $\beta_{0 \ell}$ terms are the same."

(On its own, this does not seem to make a huge difference in parameter estimates or forecast scoring where tested.)

#### Slopes
I have changed both prior distributions here and streamlined the model, removing unneeded free parameters.

Since all lineages are being treated equivalently, we do not need as much hierarchical flexibility above `mu_beta_1`, which is now just sampled directly from a Normal with fixed hyperparameters, rather than a Normal with variable ones. This also reduces the variance on the slopes towards more reasonable parameter values, and removes 2 parameters, streamlining the DAG a bit.

Beyond this, I moved us to a 0-mode prior for the variance component of the MVN prior on $\boldsymbol{\Sigma}$, where we had one which favored quite large variances. The mean of this prior is set such that the marginal variance on the slopes matches the independent model at the mean. (The model pulls this up, which I am not pleased with, but with which we can deal later.)

#### Future note
We may want to consider:
- Revisiting the prior on the diagonal of $\boldsymbol{\Sigma}$.
- Adaptive strength of pooling. It is currently a function of the priors on pooled vs unpooled terms, but that need not be true.
- Letting the LKJ concentration parameter be inferred.

## Scope creep
The scope-creep comes from the need to better-understand what the models "see" when fitting, since some values of hyperparameters that are, _a priori_ quite reasonable seem potentially overly restrictive. So, visualization tooling has been expanded so that:
1. We can plot our forecasts with data, this is split into:
  1. Adding the option to plot data used to fit the model to `forecast_{model_name}.png`
  2. Adding an `eval_{model_name}.png` that plots the parameters with the evaluation data for the forecast period.
2. The pure-data-viz script has been expanded to allow filtering to data available during the period and only including specific locations (though it remains a location-aggregated tool for now)

I have chosen to split 1 into 1.1 and 1.2 for now because I think it's important to understand what was input data and what was not, and our situation makes that otherwise hard (high-dimensional models with many ways to slice things, plus there is significant temporal overlap between our evaluation and modeling datasets).