### PR TITLE
use python 3.12 or higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Scott Olesen <ulp7@cdc.gov>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.12"
 numpyro = "^0.15.0"
 numpy = "^2.0.0"
 polars = "^1.1.0"


### PR DESCRIPTION
`pathlib` introduced some notable changes that require python3.12, upon which #39 is built.

This PR upates the `poetry` python dependency to match accordingly.