### PR TITLE
Count-based evaluation

### DIFF
--- a/linmod/data.py
+++ b/linmod/data.py
@@ -29,11 +29,12 @@ from typing import Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+import numpy as np
 import polars as pl
 import yaml
 import zstandard
 
-from .utils import ValidPath, print_message
+from .utils import ValidPath, expand_grid, print_message
 
 DEFAULT_CONFIG = {
     "data": {
@@ -136,6 +137,67 @@ Default configuration for data download, preprocessing, and export.
 The configuration dictionary expects all of the following entries in a
 `data` key.
 """
+
+
+class ModelData:
+    """
+    Mostly a polars DataFrame of filtered (group x time) x lineage count data.
+
+    Stores some extra information for convenience.
+
+    Takes in data as processed by running `python3 -m linmod.data [path/to/config.yaml]`.
+    """
+
+    def __init__(self, data: pl.DataFrame, t_min: int, t_max: int):
+        assert set(["lineage", "count", "fd_offset", "division"]).issubset(
+            data.columns
+        )
+
+        self.all_times = np.array(range(t_min, t_max + 1))
+        self.gt = len(self.all_times) * len(data["division"].unique().sort())
+        self.division_names, self.divisions = np.unique(
+            data["division"], return_inverse=True
+        )
+        self.lineage_names = sorted(data["lineage"].unique())
+
+        all_gt = expand_grid(
+            division=data["division"].unique().sort(),
+            fd_offset=self.all_times,
+        ).with_columns(index=pl.int_range(self.gt))
+
+        obs_gt = (
+            data.group_by(["fd_offset", "division"])
+            .agg(pl.col("count").sum())
+            .sort("division", "fd_offset")
+            .select("fd_offset", "division", "count")
+        )
+
+        data = data.pivot(
+            on="lineage", index=["fd_offset", "division"], values="count"
+        ).fill_null(0)
+
+        self.counts = (
+            data.sort("division", "fd_offset")
+            .select(self.lineage_names)
+            .to_numpy()
+        )
+
+        self.n = obs_gt["count"].to_numpy()
+
+        all_gt.join(
+            obs_gt, how="left", on=["fd_offset", "division"], validate="1:1"
+        )
+
+        self.slicer = tuple(
+            (
+                all_gt.join(
+                    obs_gt,
+                    how="left",
+                    on=["fd_offset", "division"],
+                    validate="1:1",
+                ).filter(pl.col("count").is_not_null())
+            )["index"]
+        )
 
 
 def main(cfg: Optional[dict]):

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -102,13 +102,13 @@ def score(
 ) -> float:
     if agg != "sum_all":
         raise RuntimeError(
-            "I don't know how to aggregate scores except for agg='all'."
+            "I don't know how to aggregate scores except for agg='sum_all'."
         )
     return (
         fun(data, samples, samples_are_phi, **kwargs)
         .collect()
         .get_column("score")
-        .sum
+        .sum()
     )
 
 
@@ -145,7 +145,6 @@ def energy_score_per_division_day(data, samples, samples_are_phi, **kwargs):
 
     Returns a DataFrame with columns `(division, fd_offset, energy_score)`.
     """
-
     p = kwargs["p"] if "p" in kwargs.keys() else 2
     if samples_are_phi:
         col = "phi"
@@ -155,12 +154,12 @@ def energy_score_per_division_day(data, samples, samples_are_phi, **kwargs):
     # First, we will gather the values of phi' we will use for (phi-phi')
     samples = (
         samples.group_by("fd_offset", "division", "lineage")
-        .agg(pl.col("sample_index"), pl.col("sampled"))
+        .agg(pl.col("sample_index"), pl.col(col))
         .with_columns(
             sample_index=pl_list_cycle(pl.col("sample_index"), 1),
             replicate=pl_list_cycle(pl.col(col), 1),
         )
-        .explode("sample_index", "sampled", "replicate")
+        .explode("sample_index", col, "replicate")
     )
 
     return (

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -112,7 +112,7 @@ def generate_eval_counts(
                         predict_counts(phi_i, n, seed + i)
                     ),  # Can't create from JAX array
                     schema=lineages,
-                ).with_columns(division_days, sample_index=pl.lit(keep[i]))
+                ).with_columns(division_days, sample_index=pl.lit(keep[i] + 1))
                 for phi_i, i in zip(phi, range(phi.shape[0]))
             ]
         )

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -414,9 +414,10 @@ def multinomial_likelihood(
 def predict_counts(phi: np.ndarray, n: np.ndarray, seed):
     assert phi.shape[0] == n.shape[0]
     with numpyro.handlers.seed(rng_seed=seed):
-        numpyro.sample(
+        counts = numpyro.sample(
             "predictive", dist.Multinomial(total_count=n, probs=phi)
         )
+    return counts
 
 
 def get_convergence(

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -411,6 +411,14 @@ def multinomial_likelihood(
     return dist.Multinomial(total_count=N, logits=z)
 
 
+def predict_counts(phi: np.ndarray, n: np.ndarray, seed):
+    assert phi.shape[0] == n.shape[0]
+    with numpyro.handlers.seed(rng_seed=seed):
+        numpyro.sample(
+            "predictive", dist.Multinomial(total_count=n, probs=phi)
+        )
+
+
 def get_convergence(
     mcmc: MCMC, ignore_nan_in: list[str] = [], drop_ignorable_nan: bool = True
 ) -> pl.DataFrame:

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -1,6 +1,7 @@
 import numpy as np
 import polars as pl
 from numpy.random import default_rng
+from polars.testing import assert_frame_equal
 
 from linmod import eval
 from linmod.utils import expand_grid
@@ -57,7 +58,7 @@ def _generate_fake_samples_and_data(
     samples = samples.with_columns(
         phi=rng.normal(samples["phi_mean"], np.sqrt(sample_variance))
     ).drop("phi_mean")
-    print(samples)
+
     return samples.lazy(), data.lazy()
 
 
@@ -115,248 +116,258 @@ def test_proportions_mean_L1_norm(
     )
 
 
-# def test_proportions_mean_L1_norm2():
-#     samples, data = _generate_fake_samples_and_data(
-#         None,
-#         num_days=2,
-#         num_divisions=2,
-#         num_lineages=2,
-#         num_samples=2,
-#         sample_variance=0,
-#     )
+def test_proportions_mean_L1_norm2():
+    samples, data = _generate_fake_samples_and_data(
+        None,
+        num_days=2,
+        num_divisions=2,
+        num_lineages=2,
+        num_samples=2,
+        sample_variance=0,
+    )
 
-#     # Put in fixed values for counts and phi
-#     data = data.sort("fd_offset", "division", "lineage").with_columns(
-#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-#     )
+    # Put in fixed values for counts and phi
+    data = data.sort("fd_offset", "division", "lineage").with_columns(
+        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+    )
 
-#     samples = samples.sort(
-#         "fd_offset", "division", "sample_index", "lineage"
-#     ).with_columns(
-#         phi=pl.Series(
-#             [
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#             ]
-#         ),
-#     )
+    samples = samples.sort(
+        "fd_offset", "division", "sample_index", "lineage"
+    ).with_columns(
+        phi=pl.Series(
+            [
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+            ]
+        ),
+    )
 
-#     correct_output = pl.DataFrame(
-#         {
-#             "fd_offset": [0, 0, 1, 1],
-#             "division": [0, 1, 0, 1],
-#             "mean_norm": [
-#                 np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
-#                 + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
-#                 np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
-#                 + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
-#                 np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
-#                 + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
-#                 np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
-#                 + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
-#             ],
-#         }
-#     )
+    correct_output = pl.DataFrame(
+        {
+            "fd_offset": [0, 0, 1, 1],
+            "division": [0, 1, 0, 1],
+            "score": [
+                np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
+                + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
+                np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
+                + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
+                np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
+                + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
+                np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
+                + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
+            ],
+        }
+    )
 
-#     result = eval.mean_norm_per_division_day(
-#         data, samples, samples_are_phi=True, p=1
-#     ).collect()
+    result = eval.mean_norm_per_division_day(
+        data, samples, samples_are_phi=True, p=1
+    ).collect()
 
-#     assert_frame_equal(
-#         result,
-#         correct_output,
-#         check_row_order=False,
-#         check_column_order=True,
-#         rtol=0,
-#         atol=0,
-#     )
-
-
-# def test_proportions_L1_energy_score(
-#     num_samples=100000, sample_variance=1.4, atol=0.05
-# ):
-#     r"""
-#     Test the estimate of the energy score of phi.
-
-#     The setup is as follows:
-#     - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
-#     - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
-#     - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
-#     - Check $$
-#         \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
-#         - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
-#       $$ as reported by `eval.proportions_energy_score`
-
-#     Note that our "forecasts" are not actually proportions, but independent normal
-#     random variables. This is so that the quantity can be computed analytically.
-#     """
-
-#     rng = default_rng()
-
-#     NUM_DAYS = 4
-#     NUM_DIVISIONS = 3
-#     NUM_LINEAGES = 2
-
-#     samples, data = _generate_fake_samples_and_data(
-#         rng,
-#         num_days=NUM_DAYS,
-#         num_divisions=NUM_DIVISIONS,
-#         num_lineages=NUM_LINEAGES,
-#         num_samples=num_samples,
-#         sample_variance=sample_variance,
-#     )
-
-#     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
-#     # its mean.
-#     # The mean absolute error of a normal random variable from its mean is
-#     # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
-#     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
-
-#     term1 = (
-#         np.sqrt(2 * sample_variance / np.pi)
-#         * NUM_DAYS
-#         * NUM_DIVISIONS
-#         * NUM_LINEAGES
-#     )
-
-#     # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
-#     # an independent copy of itself.
-#     # The mean absolute error of a normal random variable from an independent copy is
-#     # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
-#     # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
-
-#     term2 = (
-#         (2 * np.sqrt(sample_variance / np.pi))
-#         * NUM_DAYS
-#         * NUM_DIVISIONS
-#         * NUM_LINEAGES
-#     )
-
-#     assert np.isclose(
-#         eval.score(data, eval.energy_score_per_division_day, samples, samples_are_phi=True, p=1),
-#         term1 - 0.5 * term2,
-#         atol=atol,
-#     )
+    assert_frame_equal(
+        result,
+        correct_output,
+        check_row_order=False,
+        check_column_order=True,
+        rtol=0,
+        atol=0,
+    )
 
 
-# def test_proportions_L1_energy_score2():
-#     samples, data = _generate_fake_samples_and_data(
-#         None,
-#         num_days=2,
-#         num_divisions=2,
-#         num_lineages=2,
-#         num_samples=3,
-#         sample_variance=0,
-#     )
+def test_proportions_L1_energy_score(
+    num_samples=100000, sample_variance=1.4, atol=0.05
+):
+    r"""
+    Test the estimate of the energy score of phi.
 
-#     # Put in fixed values for counts and phi
-#     data = data.sort("fd_offset", "division", "lineage").with_columns(
-#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-#     )
+    The setup is as follows:
+    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
+    - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+    - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
+    - Check $$
+        \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
+        - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
+      $$ as reported by `eval.proportions_energy_score`
 
-#     samples = samples.sort(
-#         "fd_offset", "division", "sample_index", "lineage"
-#     ).with_columns(
-#         phi=pl.Series(
-#             [
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.1,
-#                 0.9,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#                 0.1,
-#                 0.9,
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.1,
-#                 0.9,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#                 0.1,
-#                 0.9,
-#             ]
-#         ),
-#     )
+    Note that our "forecasts" are not actually proportions, but independent normal
+    random variables. This is so that the quantity can be computed analytically.
+    """
 
-#     correct_output = pl.DataFrame(
-#         {
-#             "fd_offset": [0, 0, 1, 1],
-#             "division": [0, 1, 0, 1],
-#             "energy_score": [
-#                 np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
-#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-#                 ).mean(),
-#                 np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
-#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-#                 ).mean(),
-#                 np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
-#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-#                 ).mean(),
-#                 np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
-#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-#                 ).mean(),
-#             ],
-#         }
-#     )
+    rng = default_rng()
 
-#     result = eval.energy_score_per_division_day(
-#         data, samples, samples_are_phi=True, p=1
-#     ).collect()
+    NUM_DAYS = 4
+    NUM_DIVISIONS = 3
+    NUM_LINEAGES = 2
 
-#     assert_frame_equal(
-#         result,
-#         correct_output,
-#         check_row_order=False,
-#         check_column_order=True,
-#     )
+    samples, data = _generate_fake_samples_and_data(
+        rng,
+        num_days=NUM_DAYS,
+        num_divisions=NUM_DIVISIONS,
+        num_lineages=NUM_LINEAGES,
+        num_samples=num_samples,
+        sample_variance=sample_variance,
+    )
+    print("++++++++++++++ SAMPLES ++++++++++++++")
+    print(samples.collect())
+    print("++++++++++++++ DATA ++++++++++++++")
+    print(data.collect())
+
+    # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
+    # its mean.
+    # The mean absolute error of a normal random variable from its mean is
+    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
+    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
+
+    term1 = (
+        np.sqrt(2 * sample_variance / np.pi)
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES
+    )
+
+    # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
+    # an independent copy of itself.
+    # The mean absolute error of a normal random variable from an independent copy is
+    # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
+    # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
+
+    term2 = (
+        (2 * np.sqrt(sample_variance / np.pi))
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES
+    )
+
+    assert np.isclose(
+        eval.score(
+            data,
+            eval.energy_score_per_division_day,
+            samples,
+            samples_are_phi=True,
+            p=1,
+        ),
+        term1 - 0.5 * term2,
+        atol=atol,
+    )
+
+
+def test_proportions_L1_energy_score2():
+    samples, data = _generate_fake_samples_and_data(
+        None,
+        num_days=2,
+        num_divisions=2,
+        num_lineages=2,
+        num_samples=3,
+        sample_variance=0,
+    )
+
+    # Put in fixed values for counts and phi
+    data = data.sort("fd_offset", "division", "lineage").with_columns(
+        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+    )
+
+    samples = samples.sort(
+        "fd_offset", "division", "sample_index", "lineage"
+    ).with_columns(
+        phi=pl.Series(
+            [
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.1,
+                0.9,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+                0.1,
+                0.9,
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.1,
+                0.9,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+                0.1,
+                0.9,
+            ]
+        ),
+    )
+
+    correct_output = pl.DataFrame(
+        {
+            "fd_offset": [0, 0, 1, 1],
+            "division": [0, 1, 0, 1],
+            "score": [
+                np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
+                + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+                ).mean(),
+                np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
+                + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+                ).mean(),
+                np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
+                + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+                ).mean(),
+                np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
+                + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+                ).mean(),
+            ],
+        }
+    )
+
+    result = eval.energy_score_per_division_day(
+        data, samples, samples_are_phi=True, p=1
+    ).collect()
+
+    assert_frame_equal(
+        result,
+        correct_output,
+        check_row_order=False,
+        check_column_order=True,
+    )

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -102,8 +102,8 @@ def test_proportions_mean_L1_norm(
 
     assert np.isclose(
         eval.score(
-            data,
             eval.mean_norm_per_division_day,
+            data,
             samples,
             samples_are_phi=True,
             p=1,
@@ -220,10 +220,6 @@ def test_proportions_L1_energy_score(
         num_samples=num_samples,
         sample_variance=sample_variance,
     )
-    print("++++++++++++++ SAMPLES ++++++++++++++")
-    print(samples.collect())
-    print("++++++++++++++ DATA ++++++++++++++")
-    print(data.collect())
 
     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
     # its mean.
@@ -253,8 +249,8 @@ def test_proportions_L1_energy_score(
 
     assert np.isclose(
         eval.score(
-            data,
             eval.energy_score_per_division_day,
+            data,
             samples,
             samples_are_phi=True,
             p=1,

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -1,7 +1,5 @@
 import numpy as np
-import polars as pl
 from numpy.random import default_rng
-from polars.testing import assert_frame_equal
 
 from linmod import eval
 from linmod.utils import expand_grid
@@ -36,13 +34,14 @@ def _generate_fake_samples_and_data(
 
     # Generate fake forecasts of population proportions
     samples = eval._merge_samples_and_data(
+        data,
         expand_grid(
             fd_offset=range(num_days),
             division=range(num_divisions),
             lineage=range(num_lineages),
             sample_index=range(num_samples),
         ),
-        data,
+        samples_are_phi=True,
     ).rename({"phi": "phi_mean"})
 
     samples = samples.with_columns(
@@ -91,7 +90,13 @@ def test_proportions_mean_L1_norm(
     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
 
     assert np.isclose(
-        eval.proportions_mean_norm(samples, data, p=1),
+        eval.score(
+            data,
+            eval.mean_norm_per_division_day,
+            samples,
+            samples_are_phi=True,
+            p=1,
+        ),
         np.sqrt(sample_variance * 2 / np.pi)
         * NUM_DAYS
         * NUM_DIVISIONS
@@ -100,248 +105,248 @@ def test_proportions_mean_L1_norm(
     )
 
 
-def test_proportions_mean_L1_norm2():
-    samples, data = _generate_fake_samples_and_data(
-        None,
-        num_days=2,
-        num_divisions=2,
-        num_lineages=2,
-        num_samples=2,
-        sample_variance=0,
-    )
+# def test_proportions_mean_L1_norm2():
+#     samples, data = _generate_fake_samples_and_data(
+#         None,
+#         num_days=2,
+#         num_divisions=2,
+#         num_lineages=2,
+#         num_samples=2,
+#         sample_variance=0,
+#     )
 
-    # Put in fixed values for counts and phi
-    data = data.sort("fd_offset", "division", "lineage").with_columns(
-        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-    )
+#     # Put in fixed values for counts and phi
+#     data = data.sort("fd_offset", "division", "lineage").with_columns(
+#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+#     )
 
-    samples = samples.sort(
-        "fd_offset", "division", "sample_index", "lineage"
-    ).with_columns(
-        phi=pl.Series(
-            [
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-            ]
-        ),
-    )
+#     samples = samples.sort(
+#         "fd_offset", "division", "sample_index", "lineage"
+#     ).with_columns(
+#         phi=pl.Series(
+#             [
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#             ]
+#         ),
+#     )
 
-    correct_output = pl.DataFrame(
-        {
-            "fd_offset": [0, 0, 1, 1],
-            "division": [0, 1, 0, 1],
-            "mean_norm": [
-                np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
-                + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
-                np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
-                + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
-                np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
-                + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
-                np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
-                + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
-            ],
-        }
-    )
+#     correct_output = pl.DataFrame(
+#         {
+#             "fd_offset": [0, 0, 1, 1],
+#             "division": [0, 1, 0, 1],
+#             "mean_norm": [
+#                 np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
+#                 + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
+#                 np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
+#                 + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
+#                 np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
+#                 + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
+#                 np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
+#                 + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
+#             ],
+#         }
+#     )
 
-    result = eval.proportions_mean_norm_per_division_day(
-        samples, data, p=1
-    ).collect()
+#     result = eval.mean_norm_per_division_day(
+#         data, samples, samples_are_phi=True, p=1
+#     ).collect()
 
-    assert_frame_equal(
-        result,
-        correct_output,
-        check_row_order=False,
-        check_column_order=True,
-        rtol=0,
-        atol=0,
-    )
-
-
-def test_proportions_L1_energy_score(
-    num_samples=100000, sample_variance=1.4, atol=0.05
-):
-    r"""
-    Test the estimate of the energy score of phi.
-
-    The setup is as follows:
-    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
-    - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
-    - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
-    - Check $$
-        \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
-        - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
-      $$ as reported by `eval.proportions_energy_score`
-
-    Note that our "forecasts" are not actually proportions, but independent normal
-    random variables. This is so that the quantity can be computed analytically.
-    """
-
-    rng = default_rng()
-
-    NUM_DAYS = 4
-    NUM_DIVISIONS = 3
-    NUM_LINEAGES = 2
-
-    samples, data = _generate_fake_samples_and_data(
-        rng,
-        num_days=NUM_DAYS,
-        num_divisions=NUM_DIVISIONS,
-        num_lineages=NUM_LINEAGES,
-        num_samples=num_samples,
-        sample_variance=sample_variance,
-    )
-
-    # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
-    # its mean.
-    # The mean absolute error of a normal random variable from its mean is
-    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
-    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
-
-    term1 = (
-        np.sqrt(2 * sample_variance / np.pi)
-        * NUM_DAYS
-        * NUM_DIVISIONS
-        * NUM_LINEAGES
-    )
-
-    # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
-    # an independent copy of itself.
-    # The mean absolute error of a normal random variable from an independent copy is
-    # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
-    # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
-
-    term2 = (
-        (2 * np.sqrt(sample_variance / np.pi))
-        * NUM_DAYS
-        * NUM_DIVISIONS
-        * NUM_LINEAGES
-    )
-
-    assert np.isclose(
-        eval.proportions_energy_score(samples, data, p=1),
-        term1 - 0.5 * term2,
-        atol=atol,
-    )
+#     assert_frame_equal(
+#         result,
+#         correct_output,
+#         check_row_order=False,
+#         check_column_order=True,
+#         rtol=0,
+#         atol=0,
+#     )
 
 
-def test_proportions_L1_energy_score2():
-    samples, data = _generate_fake_samples_and_data(
-        None,
-        num_days=2,
-        num_divisions=2,
-        num_lineages=2,
-        num_samples=3,
-        sample_variance=0,
-    )
+# def test_proportions_L1_energy_score(
+#     num_samples=100000, sample_variance=1.4, atol=0.05
+# ):
+#     r"""
+#     Test the estimate of the energy score of phi.
 
-    # Put in fixed values for counts and phi
-    data = data.sort("fd_offset", "division", "lineage").with_columns(
-        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-    )
+#     The setup is as follows:
+#     - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
+#     - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+#     - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
+#     - Check $$
+#         \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
+#         - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
+#       $$ as reported by `eval.proportions_energy_score`
 
-    samples = samples.sort(
-        "fd_offset", "division", "sample_index", "lineage"
-    ).with_columns(
-        phi=pl.Series(
-            [
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.1,
-                0.9,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.1,
-                0.9,
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.1,
-                0.9,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.1,
-                0.9,
-            ]
-        ),
-    )
+#     Note that our "forecasts" are not actually proportions, but independent normal
+#     random variables. This is so that the quantity can be computed analytically.
+#     """
 
-    correct_output = pl.DataFrame(
-        {
-            "fd_offset": [0, 0, 1, 1],
-            "division": [0, 1, 0, 1],
-            "energy_score": [
-                np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
-                + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-                ).mean(),
-                np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
-                + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-                ).mean(),
-                np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
-                + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-                ).mean(),
-                np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
-                + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-                ).mean(),
-            ],
-        }
-    )
+#     rng = default_rng()
 
-    result = eval.proportions_energy_score_per_division_day(
-        samples, data, p=1
-    ).collect()
+#     NUM_DAYS = 4
+#     NUM_DIVISIONS = 3
+#     NUM_LINEAGES = 2
 
-    assert_frame_equal(
-        result,
-        correct_output,
-        check_row_order=False,
-        check_column_order=True,
-    )
+#     samples, data = _generate_fake_samples_and_data(
+#         rng,
+#         num_days=NUM_DAYS,
+#         num_divisions=NUM_DIVISIONS,
+#         num_lineages=NUM_LINEAGES,
+#         num_samples=num_samples,
+#         sample_variance=sample_variance,
+#     )
+
+#     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
+#     # its mean.
+#     # The mean absolute error of a normal random variable from its mean is
+#     # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
+#     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
+
+#     term1 = (
+#         np.sqrt(2 * sample_variance / np.pi)
+#         * NUM_DAYS
+#         * NUM_DIVISIONS
+#         * NUM_LINEAGES
+#     )
+
+#     # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
+#     # an independent copy of itself.
+#     # The mean absolute error of a normal random variable from an independent copy is
+#     # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
+#     # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
+
+#     term2 = (
+#         (2 * np.sqrt(sample_variance / np.pi))
+#         * NUM_DAYS
+#         * NUM_DIVISIONS
+#         * NUM_LINEAGES
+#     )
+
+#     assert np.isclose(
+#         eval.score(data, eval.energy_score_per_division_day, samples, samples_are_phi=True, p=1),
+#         term1 - 0.5 * term2,
+#         atol=atol,
+#     )
+
+
+# def test_proportions_L1_energy_score2():
+#     samples, data = _generate_fake_samples_and_data(
+#         None,
+#         num_days=2,
+#         num_divisions=2,
+#         num_lineages=2,
+#         num_samples=3,
+#         sample_variance=0,
+#     )
+
+#     # Put in fixed values for counts and phi
+#     data = data.sort("fd_offset", "division", "lineage").with_columns(
+#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+#     )
+
+#     samples = samples.sort(
+#         "fd_offset", "division", "sample_index", "lineage"
+#     ).with_columns(
+#         phi=pl.Series(
+#             [
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.1,
+#                 0.9,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#                 0.1,
+#                 0.9,
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.1,
+#                 0.9,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#                 0.1,
+#                 0.9,
+#             ]
+#         ),
+#     )
+
+#     correct_output = pl.DataFrame(
+#         {
+#             "fd_offset": [0, 0, 1, 1],
+#             "division": [0, 1, 0, 1],
+#             "energy_score": [
+#                 np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
+#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+#                 ).mean(),
+#                 np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
+#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+#                 ).mean(),
+#                 np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
+#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+#                 ).mean(),
+#                 np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
+#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+#                 ).mean(),
+#             ],
+#         }
+#     )
+
+#     result = eval.energy_score_per_division_day(
+#         data, samples, samples_are_phi=True, p=1
+#     ).collect()
+
+#     assert_frame_equal(
+#         result,
+#         correct_output,
+#         check_row_order=False,
+#         check_column_order=True,
+#     )

--- a/retrospective-forecasting/config/early-21L.yaml
+++ b/retrospective-forecasting/config/early-21L.yaml
@@ -56,7 +56,10 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/early-21L
 
+  # Number of posterior samples for which predictive counts will be generated
+  num_post_pred_samps: 500
+
   # How should forecasts be evaluated?
   metrics:
-    - proportions_mean_norm
-    - proportions_energy_score
+    - mean_norm
+    - energy_score

--- a/retrospective-forecasting/config/late-21L.yaml
+++ b/retrospective-forecasting/config/late-21L.yaml
@@ -56,7 +56,10 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/late-21L
 
+  # Number of posterior samples for which predictive counts will be generated
+  num_post_pred_samps: 500
+
   # How should forecasts be evaluated?
   metrics:
-    - proportions_mean_norm
-    - proportions_energy_score
+    - mean_norm
+    - energy_score

--- a/retrospective-forecasting/config/mid-21L.yaml
+++ b/retrospective-forecasting/config/mid-21L.yaml
@@ -56,7 +56,10 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/mid-21L
 
+  # Number of posterior samples for which predictive counts will be generated
+  num_post_pred_samps: 500
+
   # How should forecasts be evaluated?
   metrics:
-    - proportions_mean_norm
-    - proportions_energy_score
+    - mean_norm
+    - energy_score

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import shutil
 import sys
 
 import jax
@@ -40,12 +39,6 @@ model_data = pl.read_csv(
 # Fit each model
 
 forecast_dir = ValidPath(config["forecasting"]["save_dir"])
-
-if forecast_dir.exists():
-    print_message("Removing existing output directory and all contents.")
-    shutil.rmtree(forecast_dir)
-
-forecast_dir.mkdir()
 
 for model_name in config["forecasting"]["models"]:
     print_message(f"Fitting {model_name} model...")


### PR DESCRIPTION
This PR adds the ability to evaluate forecasts based on the predictive distribution of counts of sequences to the existing infrastructure for evaluation based on the posterior distribution on frequencies/proportions.

This is accomplished in three parts.
1. New functions (`linmod.eval.generate_eval_counts()`, `linmod.models.predict_counts()`, and `linmod.utils.expand_phi()`) have been added to enable the generation of posterior predictive count distributions.
2. The existing evaluation functions have been refactored such that we can feed in either posterior samples of proportions or posterior predictive samples of counts. As they are no longer proportion-specific, I also removed `proportions_` from function names as appropriate.
3. The pipeline script `retrospective-forecasting/main.py` has been changed accordingly.

To minimize code duplication moving forward, I also refactored how the per-division-day scoring gets aggregated to an overall score. In particular, I removed the middle-man functions `proportions_mean_norm()` and `proportions_energy_score()` in favor of `linmod.eval.score()` which takes in a per-division-day scoring function and does the summation across division-days. Alternative aggregation schemes can now be implemented once in this function, instead of once per scoring function.

The refactoring in (2) passes the `pytest` tests that were set up (after ensuring the tests use the correct functions).