### PR TITLE
Parquets, argparse, & normal-sized PNGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The repo has the following structure:
 ### Architecture
 
 The model is provided with lightly-preprocessed data of variant sequences from humans in the USA, from [Nextstrain](https://docs.nextstrain.org/projects/ncov/en/latest/reference/remote_inputs.html) ([data dictionary](https://docs.nextstrain.org/projects/ncov/en/latest/reference/metadata-fields.html)).
-A CSV is provided, with columns `date`, `fd_offset`, `division`, `lineage`, `count`.
+An Apache Parquet is provided, with columns `date`, `fd_offset`, `division`, `lineage`, `count`.
 Rows are uniquely identified by `(date, division, lineage)`.
 `date` and `fd_offset` can be computed from each other, given the forecast date.
 
@@ -27,7 +27,7 @@ Note that `date` is the sample collection date. `fd` refers to the forecast date
 | ...        | ...        | ...          | ...     | ...   |
 
 The model must output samples of population-level lineage proportions.
-A CSV should be provided, with columns `fd_offset`, `division`, `lineage`, `sample_index`, and `phi` (the population proportion), for `fd_offset = -30, ..., 14`.
+An Apache Parquet should be provided, with columns `fd_offset`, `division`, `lineage`, `sample_index`, and `phi` (the population proportion), for `fd_offset = -30, ..., 14`.
 Rows are uniquely identified by `(fd_offset, division, lineage, sample_index)`.
 
 | fd_offset | division | lineage | sample_index | phi            |

--- a/exploration/whole_hist_viz.py
+++ b/exploration/whole_hist_viz.py
@@ -22,7 +22,7 @@ def get_plot_data(
         last_samp_date = last_date
 
     df = (
-        pl.scan_csv(dfp, separator="\t")
+        pl.scan_parquet(dfp, separator="\t")
         .rename({"clade_nextstrain": "lineage"})
         .cast({"date": pl.Date, "date_submitted": pl.Date}, strict=False)
         .filter(

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -1,6 +1,4 @@
 """
-Usage: `python3 -m linmod.data [path/to/config.yaml]`
-
 Download the Nextstrain metadata file, preprocess it, and export it.
 
 Two datasets are exported: one for model fitting and one for evaluation.
@@ -22,8 +20,8 @@ Note that observations without a recorded date are removed, and only observation
 from human hosts are included.
 """
 
+import argparse
 import lzma
-import sys
 from datetime import datetime
 from typing import Optional
 from urllib.parse import urlparse
@@ -275,9 +273,22 @@ def main(cfg: Optional[dict]):
 if __name__ == "__main__":
     # Load configuration, if given
 
+    parser = argparse.ArgumentParser(
+        prog="python3 -m linmod.data",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        help="Path to YAML configuration file",
+    )
+    yaml_path = parser.parse_args().config
+
     cfg = None
-    if len(sys.argv) > 1:
-        with open(sys.argv[1]) as f:
+    if yaml_path is not None:
+        with open(yaml_path) as f:
             cfg = yaml.safe_load(f)["data"]
 
     main(cfg)

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -196,7 +196,7 @@ def main(cfg: Optional[dict]):
     model_all_lineages = len(config["data"]["lineages"]) == 0
 
     full_df = (
-        pl.scan_parquet(cache_path, separator="\t")
+        pl.scan_csv(cache_path, separator="\t")
         .rename({config["data"]["lineage_column_name"]: "lineage"})
         # Cast with `strict=False` replaces invalid values with null,
         # which we can then filter out. Invalid values include dates

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -264,7 +264,10 @@ def main(cfg: Optional[dict]):
         )
     else:
         print_message(
-            'Modeling the following subset of lineages, (all other lineages grouped into "other"): '
+            (
+                "Modeling the following subset of lineages, "
+                '(all other lineages grouped into "other"): '
+            )
             + str(config["data"]["lineages"])
         )
 

--- a/linmod/visualize.py
+++ b/linmod/visualize.py
@@ -12,12 +12,19 @@ from plotnine import (
 )
 
 
-def plot_forecast(forecast, counts=None):
+def plot_forecast(
+    forecast: pl.LazyFrame | pl.DataFrame,
+    counts: pl.DataFrame = None,
+    base_size=20,
+):
     summaries = forecast.group_by("division", "fd_offset", "lineage").agg(
         mean_phi=pl.mean("phi"),
         q_lower=pl.quantile("phi", 0.1),
         q_upper=pl.quantile("phi", 0.9),
     )
+
+    if isinstance(forecast, pl.LazyFrame):
+        summaries = summaries.collect()
 
     plot = (
         ggplot(summaries)
@@ -36,7 +43,7 @@ def plot_forecast(forecast, counts=None):
             size=1.5,
         )
         + facet_wrap("division")
-        + theme_bw(base_size=20)
+        + theme_bw(base_size=base_size)
         + ylab("phi")
     )
 

--- a/retrospective-forecasting/config/early-21L.yaml
+++ b/retrospective-forecasting/config/early-21L.yaml
@@ -1,8 +1,8 @@
 data:
   # Where are the processed datasets for modeling and evaluation stored?
   save_file:
-    model: data/early-21L/model.csv
-    eval: data/early-21L/eval.csv
+    model: data/early-21L/model.parquet
+    eval: data/early-21L/eval.parquet
 
   # What is the forecast date?
   # No sequences collected or reported after this date are included in the
@@ -40,7 +40,7 @@ forecasting:
     samples: 500
     chains: 4
     convergence:
-      # one of: "all" or "failing" to write a csv of ESS and PSRF
+      # one of: "all" or "failing" to write a parquet of ESS and PSRF
       # for all parameters or only those failing
       report_mode: "failing"
       # Should diagnostic plots for all reported parameters be made?

--- a/retrospective-forecasting/config/late-21L.yaml
+++ b/retrospective-forecasting/config/late-21L.yaml
@@ -1,8 +1,8 @@
 data:
   # Where are the processed datasets for modeling and evaluation stored?
   save_file:
-    model: data/late-21L/model.csv
-    eval: data/late-21L/eval.csv
+    model: data/late-21L/model.parquet
+    eval: data/late-21L/eval.parquet
 
   # What is the forecast date?
   # No sequences collected or reported after this date are included in the
@@ -40,7 +40,7 @@ forecasting:
     samples: 500
     chains: 4
     convergence:
-      # one of: "all" or "failing" to write a csv of ESS and PSRF
+      # one of: "all" or "failing" to write a parquet of ESS and PSRF
       # for all parameters or only those failing
       report_mode: "failing"
       # Should diagnostic plots for all reported parameters be made?

--- a/retrospective-forecasting/config/mid-21L.yaml
+++ b/retrospective-forecasting/config/mid-21L.yaml
@@ -1,8 +1,8 @@
 data:
   # Where are the processed datasets for modeling and evaluation stored?
   save_file:
-    model: data/mid-21L/model.csv
-    eval: data/mid-21L/eval.csv
+    model: data/mid-21L/model.parquet
+    eval: data/mid-21L/eval.parquet
 
   # What is the forecast date?
   # No sequences collected or reported after this date are included in the
@@ -40,7 +40,7 @@ forecasting:
     samples: 500
     chains: 4
     convergence:
-      # one of: "all" or "failing" to write a csv of ESS and PSRF
+      # one of: "all" or "failing" to write a parquet of ESS and PSRF
       # for all parameters or only those failing
       report_mode: "failing"
       # Should diagnostic plots for all reported parameters be made?

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -116,18 +116,11 @@ for model_name in config["forecasting"]["models"]:
 
     forecast.write_parquet(forecast_dir / f"forecasts_{model_name}.parquet")
 
-    plot_forecast(forecast, model_data).save(
-        forecast_dir / "visualizations" / f"forecasts_{model_name}.png",
-        width=40,
-        height=30,
-        dpi=300,
-        limitsize=False,
-    )
+    print_message("Done.")
 
     # Try to free up some memory
     del model, mcmc, forecast
 
-    print_message("Done.")
 
 # Load the full evaluation dataset
 

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -33,9 +33,7 @@ linmod.data.main(config)
 
 # Load the dataset used for retrospective forecasting
 
-model_data = pl.read_parquet(
-    config["data"]["save_file"]["model"], try_parse_dates=True
-)
+model_data = pl.read_parquet(config["data"]["save_file"]["model"])
 
 # Fit each model
 
@@ -133,9 +131,7 @@ for model_name in config["forecasting"]["models"]:
 
 # Load the full evaluation dataset
 
-eval_data = pl.read_parquet(
-    config["data"]["save_file"]["eval"], try_parse_dates=True
-)
+eval_data = pl.read_parquet(config["data"]["save_file"]["eval"])
 
 viz_data = eval_data.filter(
     pl.col("lineage").is_in(model_data["lineage"].unique()),
@@ -167,10 +163,10 @@ for metric_name in config["evaluation"]["metrics"]:
 
         plot_forecast(forecast.collect(), viz_data).save(
             eval_dir / "visualizations" / f"eval_{model_name}.png",
-            width=40,
-            height=30,
-            dpi=300,
-            limitsize=False,
+            width=25,
+            height=15,
+            dpi=200,
+            verbose=False,
         )
 
         print_message(" done.")

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
+import argparse
 import shutil
-import sys
 
 import jax
 import numpy as np
@@ -21,11 +21,18 @@ numpyro.set_host_device_count(4)
 
 # Load configuration
 
-if len(sys.argv) != 2:
-    print_message("Usage: python3 main.py <YAML config path>")
-    sys.exit(1)
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+parser.add_argument(
+    "config",
+    type=str,
+    help="Path to YAML configuration file",
+)
+yaml_path = parser.parse_args().config
 
-with open(sys.argv[1]) as f:
+with open(yaml_path) as f:
     config = yaml.safe_load(f)
 
 # Create the datasets


### PR DESCRIPTION
Title sums it up well.

1. Any data/samples we export were switched from CSV to parquet
2. `sys.argv` manual parsing was converted to argparse, with a nice display of the `linmod.data` module docstring when `--help` is passed
3. Forecast plot exports are reasonably sized now, and still readable

Closes:
- #18
- #40