### PR TITLE
Time standardization and slope priors

### DIFF
--- a/linmod/data.py
+++ b/linmod/data.py
@@ -29,11 +29,12 @@ from typing import Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+import numpy as np
 import polars as pl
 import yaml
 import zstandard
 
-from .utils import ValidPath, print_message
+from .utils import ValidPath, expand_grid, print_message
 
 DEFAULT_CONFIG = {
     "data": {
@@ -136,6 +137,67 @@ Default configuration for data download, preprocessing, and export.
 The configuration dictionary expects all of the following entries in a
 `data` key.
 """
+
+
+class ModelData:
+    """
+    Mostly a polars DataFrame of filtered (group x time) x lineage count data.
+
+    Stores some extra information for convenience.
+
+    Takes in data as processed by running `python3 -m linmod.data [path/to/config.yaml]`.
+    """
+
+    def __init__(self, data: pl.DataFrame, t_min: int, t_max: int):
+        assert set(["lineage", "count", "fd_offset", "division"]).issubset(
+            data.columns
+        )
+
+        self.all_times = np.array(range(t_min, t_max + 1))
+        self.gt = len(self.all_times) * len(data["division"].unique().sort())
+        self.division_names, self.divisions = np.unique(
+            data["division"], return_inverse=True
+        )
+        self.lineage_names = sorted(data["lineage"].unique())
+
+        all_gt = expand_grid(
+            division=data["division"].unique().sort(),
+            fd_offset=self.all_times,
+        ).with_columns(index=pl.int_range(self.gt))
+
+        obs_gt = (
+            data.group_by(["fd_offset", "division"])
+            .agg(pl.col("count").sum())
+            .sort("division", "fd_offset")
+            .select("fd_offset", "division", "count")
+        )
+
+        data = data.pivot(
+            on="lineage", index=["fd_offset", "division"], values="count"
+        ).fill_null(0)
+
+        self.counts = (
+            data.sort("division", "fd_offset")
+            .select(self.lineage_names)
+            .to_numpy()
+        )
+
+        self.n = obs_gt["count"].to_numpy()
+
+        all_gt.join(
+            obs_gt, how="left", on=["fd_offset", "division"], validate="1:1"
+        )
+
+        self.slicer = tuple(
+            (
+                all_gt.join(
+                    obs_gt,
+                    how="left",
+                    on=["fd_offset", "division"],
+                    validate="1:1",
+                ).filter(pl.col("count").is_not_null())
+            )["index"]
+        )
 
 
 def main(cfg: Optional[dict]):

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -102,13 +102,13 @@ def score(
 ) -> float:
     if agg != "sum_all":
         raise RuntimeError(
-            "I don't know how to aggregate scores except for agg='all'."
+            "I don't know how to aggregate scores except for agg='sum_all'."
         )
     return (
         fun(data, samples, samples_are_phi, **kwargs)
         .collect()
         .get_column("score")
-        .sum
+        .sum()
     )
 
 
@@ -145,7 +145,6 @@ def energy_score_per_division_day(data, samples, samples_are_phi, **kwargs):
 
     Returns a DataFrame with columns `(division, fd_offset, energy_score)`.
     """
-
     p = kwargs["p"] if "p" in kwargs.keys() else 2
     if samples_are_phi:
         col = "phi"
@@ -155,12 +154,12 @@ def energy_score_per_division_day(data, samples, samples_are_phi, **kwargs):
     # First, we will gather the values of phi' we will use for (phi-phi')
     samples = (
         samples.group_by("fd_offset", "division", "lineage")
-        .agg(pl.col("sample_index"), pl.col("sampled"))
+        .agg(pl.col("sample_index"), pl.col(col))
         .with_columns(
             sample_index=pl_list_cycle(pl.col("sample_index"), 1),
             replicate=pl_list_cycle(pl.col(col), 1),
         )
-        .explode("sample_index", "sampled", "replicate")
+        .explode("sample_index", col, "replicate")
     )
 
     return (

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -112,7 +112,7 @@ def generate_eval_counts(
                         predict_counts(phi_i, n, seed + i)
                     ),  # Can't create from JAX array
                     schema=lineages,
-                ).with_columns(division_days, sample_index=pl.lit(keep[i]))
+                ).with_columns(division_days, sample_index=pl.lit(keep[i] + 1))
                 for phi_i, i in zip(phi, range(phi.shape[0]))
             ]
         )

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -414,9 +414,10 @@ def multinomial_likelihood(
 def predict_counts(phi: np.ndarray, n: np.ndarray, seed):
     assert phi.shape[0] == n.shape[0]
     with numpyro.handlers.seed(rng_seed=seed):
-        numpyro.sample(
+        counts = numpyro.sample(
             "predictive", dist.Multinomial(total_count=n, probs=phi)
         )
+    return counts
 
 
 def get_convergence(

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -411,6 +411,14 @@ def multinomial_likelihood(
     return dist.Multinomial(total_count=N, logits=z)
 
 
+def predict_counts(phi: np.ndarray, n: np.ndarray, seed):
+    assert phi.shape[0] == n.shape[0]
+    with numpyro.handlers.seed(rng_seed=seed):
+        numpyro.sample(
+            "predictive", dist.Multinomial(total_count=n, probs=phi)
+        )
+
+
 def get_convergence(
     mcmc: MCMC, ignore_nan_in: list[str] = [], drop_ignorable_nan: bool = True
 ) -> pl.DataFrame:

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -97,14 +97,12 @@ class HierarchicalDivisionsModel:
             mu_beta_0 = numpyro.sample(
                 "mu_beta_0",
                 dist.Normal(0, 1.0),
-                sample_shape=(self.num_lineages,),
             )
 
             # mu_beta_1[l] is the mean of the slope for lineage l
             mu_beta_1 = numpyro.sample(
                 "mu_beta_1",
                 dist.Normal(0, 1.0),
-                sample_shape=(self.num_lineages,),
             )
 
             with numpyro.plate(
@@ -114,10 +112,6 @@ class HierarchicalDivisionsModel:
                 z_0 = numpyro.sample(
                     "z_0",
                     dist.Normal(0, 1.0),
-                    sample_shape=(
-                        self.num_divisions,
-                        self.num_lineages,
-                    ),
                 )
                 beta_0 = numpyro.deterministic(
                     "beta_0",
@@ -128,10 +122,6 @@ class HierarchicalDivisionsModel:
                 z_1 = numpyro.sample(
                     "z_1",
                     dist.Normal(0, 1),
-                    sample_shape=(
-                        self.num_divisions,
-                        self.num_lineages,
-                    ),
                 )
                 beta_1 = numpyro.deterministic(
                     "beta_1",
@@ -177,6 +167,73 @@ class HierarchicalDivisionsModel:
             )
             .drop("beta_0", "beta_1")
         )
+
+
+class HierarchicalCorrelatedDeviationsModel(HierarchicalDivisionsModel):
+    def numpyro_model(self):
+        # rho_intercept determines strength of intercept pooling
+        rho_intercept = numpyro.sample(
+            "rho_intercept",
+            dist.Beta(1.0, 1.0),
+        )
+
+        # rho_slope determines strength of slope pooling
+        rho_slope = numpyro.sample(
+            "rho_slope",
+            dist.Beta(1.0, 1.0),
+        )
+
+        # beta_0[g, l] is the intercept for lineage l in division g
+        mu_beta_0 = numpyro.sample(
+            "mu_beta_0",
+            dist.Normal(0, 1.0),
+            sample_shape=(self.num_lineages,),
+        )
+        z_0 = numpyro.sample(
+            "z_0",
+            dist.Normal(0, 1.0),
+            sample_shape=(self.num_divisions, self.num_lineages),
+        )
+        beta_0 = numpyro.deterministic(
+            "beta_0",
+            (mu_beta_0 * jnp.sqrt(rho_intercept))
+            + (z_0 * jnp.sqrt(1.0 - rho_intercept)),
+        )
+
+        # mu_beta_1[l] is the mean of the slope for lineage l
+        mu_beta_1 = numpyro.sample(
+            "mu_beta_1",
+            dist.Normal(0, 1.0),
+            sample_shape=(self.num_lineages,),
+        )
+
+        # beta_1[g, l] is the slope for lineage l in division g
+        sigma_beta_1 = numpyro.deterministic(
+            "sigma_beta_1",
+            0.25 * jnp.sqrt(1.0 - rho_slope) * np.ones(self.num_lineages),
+        )
+        Omega_decomposition = numpyro.sample(
+            "Omega_decomposition",
+            dist.LKJCholesky(self.num_lineages, 2),
+        )
+        # A faster version of `np.diag(sigma_beta_1) @ Omega_decomposition`
+        Sigma_decomposition = sigma_beta_1[:, None] * Omega_decomposition
+        z_1 = numpyro.sample(
+            "z_1",
+            dist.Normal(0, 1),
+            sample_shape=(self.num_divisions, self.num_lineages),
+        )
+        beta_1 = numpyro.deterministic(
+            "beta_1",
+            mu_beta_1 + z_1 @ Sigma_decomposition.T,
+        )
+
+        likelihood = multinomial_likelihood(
+            beta_0, beta_1, self.divisions, self.time, self.N
+        )
+
+        # Y[i, l] is the count of lineage l for observation i
+        numpyro.sample("Y", likelihood, obs=self.counts)
 
 
 class IndependentDivisionsModel:

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -1,7 +1,9 @@
 import string
+import warnings
 from itertools import product
 from typing import Iterable
 
+import jax.numpy as jnp
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
@@ -48,9 +50,7 @@ class HierarchicalDivisionsModel:
         )
         self.counts = data.select(self.lineage_names).to_numpy()
 
-        time = data["fd_offset"].to_numpy()
-        self._time_standardizer = lambda t: (t - time.mean()) / time.std()
-        self.time = self._time_standardizer(time)
+        self.time = data["fd_offset"].to_numpy()
 
         if (
             num_lineages is not None
@@ -71,50 +71,69 @@ class HierarchicalDivisionsModel:
             self.num_divisions = len(self.division_names)
 
     def numpyro_model(self):
+        # rho_intercept determines strength of intercept pooling
+        rho_intercept = numpyro.sample(
+            "rho_intercept",
+            dist.Beta(1.0, 1.0),
+        )
+
+        # rho_slope determines strength of slope pooling
+        rho_slope = numpyro.sample(
+            "rho_slope",
+            dist.Beta(1.0, 1.0),
+        )
+
         # beta_0[g, l] is the intercept for lineage l in division g
         mu_beta_0 = numpyro.sample(
             "mu_beta_0",
-            dist.Normal(0, 0.70710678),
-            sample_shape=(self.num_lineages,),
-        )
-        sigma_beta_0 = numpyro.sample(
-            "sigma_beta_0",
-            dist.Exponential(1.0),
+            dist.Normal(0, 1.0),
             sample_shape=(self.num_lineages,),
         )
         z_0 = numpyro.sample(
             "z_0",
-            dist.Normal(0, 0.70710678),
+            dist.Normal(0, 1.0),
             sample_shape=(self.num_divisions, self.num_lineages),
         )
         beta_0 = numpyro.deterministic(
             "beta_0",
-            mu_beta_0 + sigma_beta_0 * z_0,
+            (mu_beta_0 * jnp.sqrt(rho_intercept))
+            + (z_0 * jnp.sqrt(1.0 - rho_intercept)),
         )
 
         # mu_beta_1[l] is the mean of the slope for lineage l
         mu_beta_1 = numpyro.sample(
             "mu_beta_1",
-            dist.Normal(0, 0.1767767),
+            dist.Normal(0, 1.0),
             sample_shape=(self.num_lineages,),
         )
 
         # beta_1[g, l] is the slope for lineage l in division g
-        sigma_beta_1 = 0.1767767 * np.ones(self.num_lineages)
-        Omega_decomposition = numpyro.sample(
-            "Omega_decomposition",
-            dist.LKJCholesky(self.num_lineages, 2),
+        sigma_beta_1 = numpyro.deterministic(
+            "sigma_beta_1",
+            0.25 * jnp.sqrt(1.0 - rho_slope),
         )
-        # A faster version of `np.diag(sigma_beta_1) @ Omega_decomposition`
-        Sigma_decomposition = sigma_beta_1[:, None] * Omega_decomposition
+        # sigma_beta_1 = numpyro.deterministic(
+        #     "sigma_beta_1",
+        #     0.25 * jnp.sqrt(1.0 - rho_slope) * np.ones(self.num_lineages),
+        # )
+        # Omega_decomposition = numpyro.sample(
+        #     "Omega_decomposition",
+        #     dist.LKJCholesky(self.num_lineages, 2),
+        # )
+        # # A faster version of `np.diag(sigma_beta_1) @ Omega_decomposition`
+        # Sigma_decomposition = sigma_beta_1[:, None] * Omega_decomposition
         z_1 = numpyro.sample(
             "z_1",
             dist.Normal(0, 1),
             sample_shape=(self.num_divisions, self.num_lineages),
         )
+        # beta_1 = numpyro.deterministic(
+        #     "beta_1",
+        #     (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope)) + z_1 @ Sigma_decomposition.T,
+        # )
         beta_1 = numpyro.deterministic(
             "beta_1",
-            mu_beta_1 + z_1 @ Sigma_decomposition.T,
+            (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope)) + z_1 * sigma_beta_1,
         )
 
         likelihood = multinomial_likelihood(
@@ -150,9 +169,7 @@ class HierarchicalDivisionsModel:
             .join(parameter_samples, on="sample_index")
             .with_columns(
                 phi=pl_softmax(
-                    pl.col("beta_0")
-                    + pl.col("beta_1")
-                    * self._time_standardizer(pl.col("fd_offset")),
+                    pl.col("beta_0") + pl.col("beta_1") * pl.col("fd_offset"),
                 ).over("sample_index", "division", "fd_offset")
             )
             .drop("beta_0", "beta_1")
@@ -194,9 +211,7 @@ class IndependentDivisionsModel:
         )
         self.counts = data.select(self.lineage_names).to_numpy()
 
-        time = data["fd_offset"].to_numpy()
-        self._time_standardizer = lambda t: (t - time.mean()) / time.std()
-        self.time = self._time_standardizer(time)
+        self.time = data["fd_offset"].to_numpy()
 
         if num_lineages is not None and N is not None:
             self.N = N.to_numpy()
@@ -264,9 +279,7 @@ class IndependentDivisionsModel:
             .join(parameter_samples, on="sample_index")
             .with_columns(
                 phi=pl_softmax(
-                    pl.col("beta_0")
-                    + pl.col("beta_1")
-                    * self._time_standardizer(pl.col("fd_offset")),
+                    pl.col("beta_0") + pl.col("beta_1") * pl.col("fd_offset"),
                 ).over("sample_index", "division", "fd_offset")
             )
             .drop("beta_0", "beta_1")
@@ -486,7 +499,7 @@ def get_convergence(
         nans = nans.filter(~pl.col("param_no_dim").is_in(ignore_nan_in))
         if nans.shape[0] > 0:
             bad = nans["param"].unique().to_list()
-            raise RuntimeError(
+            warnings.warn(
                 "Found unexpected NaN convergence values for parameters: "
                 + str(bad)
             )

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -71,19 +71,17 @@ class HierarchicalDivisionsModel:
             self.num_divisions = len(self.division_names)
 
     def numpyro_model(self):
-        # # rho_intercept determines strength of intercept pooling
-        # rho_intercept = numpyro.sample(
-        #     "rho_intercept",
-        #     dist.Beta(1.0, 1.0),
-        # )
+        # rho_intercept determines strength of intercept pooling
+        rho_intercept = numpyro.sample(
+            "rho_intercept",
+            dist.Beta(1.0, 1.0),
+        )
 
-        # # rho_slope determines strength of slope pooling
-        # rho_slope = numpyro.sample(
-        #     "rho_slope",
-        #     dist.Beta(1.0, 1.0),
-        # )
-        rho_intercept = 0.0
-        rho_slope = 0.0
+        # rho_slope determines strength of slope pooling
+        rho_slope = numpyro.sample(
+            "rho_slope",
+            dist.Beta(1.0, 1.0),
+        )
 
         # beta_1[g, l] is the slope for lineage l in division g
         sigma_beta_1 = numpyro.deterministic(
@@ -95,71 +93,51 @@ class HierarchicalDivisionsModel:
             "lineage",
             self.num_lineages,
         ):
-            with numpyro.handlers.reparam(
-                config={
-                    "mu_beta_0": numpyro.infer.reparam.LocScaleReparam(
-                        centered=0
-                    ),
-                    "mu_beta_1": numpyro.infer.reparam.LocScaleReparam(
-                        centered=0
-                    ),
-                }
+            # beta_0[g, l] is the intercept for lineage l in division g
+            mu_beta_0 = numpyro.sample(
+                "mu_beta_0",
+                dist.Normal(0, 1.0),
+                sample_shape=(self.num_lineages,),
+            )
+
+            # mu_beta_1[l] is the mean of the slope for lineage l
+            mu_beta_1 = numpyro.sample(
+                "mu_beta_1",
+                dist.Normal(0, 1.0),
+                sample_shape=(self.num_lineages,),
+            )
+
+            with numpyro.plate(
+                "division",
+                np.unique(self.divisions).size,
             ):
-                # beta_0[g, l] is the intercept for lineage l in division g
-                mu_beta_0 = numpyro.sample(
-                    "mu_beta_0",
+                z_0 = numpyro.sample(
+                    "z_0",
                     dist.Normal(0, 1.0),
-                    sample_shape=(self.num_lineages,),
+                    sample_shape=(
+                        self.num_divisions,
+                        self.num_lineages,
+                    ),
+                )
+                beta_0 = numpyro.deterministic(
+                    "beta_0",
+                    (mu_beta_0 * jnp.sqrt(rho_intercept))
+                    + (z_0 * jnp.sqrt(1.0 - rho_intercept)),
                 )
 
-                # mu_beta_1[l] is the mean of the slope for lineage l
-                mu_beta_1 = numpyro.sample(
-                    "mu_beta_1",
-                    dist.Normal(0, 1.0),
-                    sample_shape=(self.num_lineages,),
+                z_1 = numpyro.sample(
+                    "z_1",
+                    dist.Normal(0, 1),
+                    sample_shape=(
+                        self.num_divisions,
+                        self.num_lineages,
+                    ),
                 )
-
-                with numpyro.plate(
-                    "division",
-                    np.unique(self.divisions).size,
-                ):
-                    with numpyro.handlers.reparam(
-                        config={
-                            "z_0": numpyro.infer.reparam.LocScaleReparam(
-                                centered=0
-                            ),
-                            "z_1": numpyro.infer.reparam.LocScaleReparam(
-                                centered=0
-                            ),
-                        }
-                    ):
-                        z_0 = numpyro.sample(
-                            "z_0",
-                            dist.Normal(0, 1.0),
-                            sample_shape=(
-                                self.num_divisions,
-                                self.num_lineages,
-                            ),
-                        )
-                        beta_0 = numpyro.deterministic(
-                            "beta_0",
-                            (mu_beta_0 * jnp.sqrt(rho_intercept))
-                            + (z_0 * jnp.sqrt(1.0 - rho_intercept)),
-                        )
-
-                        z_1 = numpyro.sample(
-                            "z_1",
-                            dist.Normal(0, 1),
-                            sample_shape=(
-                                self.num_divisions,
-                                self.num_lineages,
-                            ),
-                        )
-                        beta_1 = numpyro.deterministic(
-                            "beta_1",
-                            (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope))
-                            + z_1 * sigma_beta_1,
-                        )
+                beta_1 = numpyro.deterministic(
+                    "beta_1",
+                    (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope))
+                    + z_1 * sigma_beta_1,
+                )
 
         likelihood = multinomial_likelihood(
             beta_0, beta_1, self.divisions, self.time, self.N

--- a/linmod/models.py
+++ b/linmod/models.py
@@ -71,70 +71,95 @@ class HierarchicalDivisionsModel:
             self.num_divisions = len(self.division_names)
 
     def numpyro_model(self):
-        # rho_intercept determines strength of intercept pooling
-        rho_intercept = numpyro.sample(
-            "rho_intercept",
-            dist.Beta(1.0, 1.0),
-        )
+        # # rho_intercept determines strength of intercept pooling
+        # rho_intercept = numpyro.sample(
+        #     "rho_intercept",
+        #     dist.Beta(1.0, 1.0),
+        # )
 
-        # rho_slope determines strength of slope pooling
-        rho_slope = numpyro.sample(
-            "rho_slope",
-            dist.Beta(1.0, 1.0),
-        )
-
-        # beta_0[g, l] is the intercept for lineage l in division g
-        mu_beta_0 = numpyro.sample(
-            "mu_beta_0",
-            dist.Normal(0, 1.0),
-            sample_shape=(self.num_lineages,),
-        )
-        z_0 = numpyro.sample(
-            "z_0",
-            dist.Normal(0, 1.0),
-            sample_shape=(self.num_divisions, self.num_lineages),
-        )
-        beta_0 = numpyro.deterministic(
-            "beta_0",
-            (mu_beta_0 * jnp.sqrt(rho_intercept))
-            + (z_0 * jnp.sqrt(1.0 - rho_intercept)),
-        )
-
-        # mu_beta_1[l] is the mean of the slope for lineage l
-        mu_beta_1 = numpyro.sample(
-            "mu_beta_1",
-            dist.Normal(0, 1.0),
-            sample_shape=(self.num_lineages,),
-        )
+        # # rho_slope determines strength of slope pooling
+        # rho_slope = numpyro.sample(
+        #     "rho_slope",
+        #     dist.Beta(1.0, 1.0),
+        # )
+        rho_intercept = 0.0
+        rho_slope = 0.0
 
         # beta_1[g, l] is the slope for lineage l in division g
         sigma_beta_1 = numpyro.deterministic(
             "sigma_beta_1",
             0.25 * jnp.sqrt(1.0 - rho_slope),
         )
-        # sigma_beta_1 = numpyro.deterministic(
-        #     "sigma_beta_1",
-        #     0.25 * jnp.sqrt(1.0 - rho_slope) * np.ones(self.num_lineages),
-        # )
-        # Omega_decomposition = numpyro.sample(
-        #     "Omega_decomposition",
-        #     dist.LKJCholesky(self.num_lineages, 2),
-        # )
-        # # A faster version of `np.diag(sigma_beta_1) @ Omega_decomposition`
-        # Sigma_decomposition = sigma_beta_1[:, None] * Omega_decomposition
-        z_1 = numpyro.sample(
-            "z_1",
-            dist.Normal(0, 1),
-            sample_shape=(self.num_divisions, self.num_lineages),
-        )
-        # beta_1 = numpyro.deterministic(
-        #     "beta_1",
-        #     (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope)) + z_1 @ Sigma_decomposition.T,
-        # )
-        beta_1 = numpyro.deterministic(
-            "beta_1",
-            (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope)) + z_1 * sigma_beta_1,
-        )
+
+        with numpyro.plate(
+            "lineage",
+            self.num_lineages,
+        ):
+            with numpyro.handlers.reparam(
+                config={
+                    "mu_beta_0": numpyro.infer.reparam.LocScaleReparam(
+                        centered=0
+                    ),
+                    "mu_beta_1": numpyro.infer.reparam.LocScaleReparam(
+                        centered=0
+                    ),
+                }
+            ):
+                # beta_0[g, l] is the intercept for lineage l in division g
+                mu_beta_0 = numpyro.sample(
+                    "mu_beta_0",
+                    dist.Normal(0, 1.0),
+                    sample_shape=(self.num_lineages,),
+                )
+
+                # mu_beta_1[l] is the mean of the slope for lineage l
+                mu_beta_1 = numpyro.sample(
+                    "mu_beta_1",
+                    dist.Normal(0, 1.0),
+                    sample_shape=(self.num_lineages,),
+                )
+
+                with numpyro.plate(
+                    "division",
+                    np.unique(self.divisions).size,
+                ):
+                    with numpyro.handlers.reparam(
+                        config={
+                            "z_0": numpyro.infer.reparam.LocScaleReparam(
+                                centered=0
+                            ),
+                            "z_1": numpyro.infer.reparam.LocScaleReparam(
+                                centered=0
+                            ),
+                        }
+                    ):
+                        z_0 = numpyro.sample(
+                            "z_0",
+                            dist.Normal(0, 1.0),
+                            sample_shape=(
+                                self.num_divisions,
+                                self.num_lineages,
+                            ),
+                        )
+                        beta_0 = numpyro.deterministic(
+                            "beta_0",
+                            (mu_beta_0 * jnp.sqrt(rho_intercept))
+                            + (z_0 * jnp.sqrt(1.0 - rho_intercept)),
+                        )
+
+                        z_1 = numpyro.sample(
+                            "z_1",
+                            dist.Normal(0, 1),
+                            sample_shape=(
+                                self.num_divisions,
+                                self.num_lineages,
+                            ),
+                        )
+                        beta_1 = numpyro.deterministic(
+                            "beta_1",
+                            (mu_beta_1 * 0.25 * jnp.sqrt(rho_slope))
+                            + z_1 * sigma_beta_1,
+                        )
 
         likelihood = multinomial_likelihood(
             beta_0, beta_1, self.divisions, self.time, self.N

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -1,6 +1,7 @@
 import numpy as np
 import polars as pl
 from numpy.random import default_rng
+from polars.testing import assert_frame_equal
 
 from linmod import eval
 from linmod.utils import expand_grid
@@ -57,7 +58,7 @@ def _generate_fake_samples_and_data(
     samples = samples.with_columns(
         phi=rng.normal(samples["phi_mean"], np.sqrt(sample_variance))
     ).drop("phi_mean")
-    print(samples)
+
     return samples.lazy(), data.lazy()
 
 
@@ -115,248 +116,258 @@ def test_proportions_mean_L1_norm(
     )
 
 
-# def test_proportions_mean_L1_norm2():
-#     samples, data = _generate_fake_samples_and_data(
-#         None,
-#         num_days=2,
-#         num_divisions=2,
-#         num_lineages=2,
-#         num_samples=2,
-#         sample_variance=0,
-#     )
+def test_proportions_mean_L1_norm2():
+    samples, data = _generate_fake_samples_and_data(
+        None,
+        num_days=2,
+        num_divisions=2,
+        num_lineages=2,
+        num_samples=2,
+        sample_variance=0,
+    )
 
-#     # Put in fixed values for counts and phi
-#     data = data.sort("fd_offset", "division", "lineage").with_columns(
-#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-#     )
+    # Put in fixed values for counts and phi
+    data = data.sort("fd_offset", "division", "lineage").with_columns(
+        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+    )
 
-#     samples = samples.sort(
-#         "fd_offset", "division", "sample_index", "lineage"
-#     ).with_columns(
-#         phi=pl.Series(
-#             [
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#             ]
-#         ),
-#     )
+    samples = samples.sort(
+        "fd_offset", "division", "sample_index", "lineage"
+    ).with_columns(
+        phi=pl.Series(
+            [
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+            ]
+        ),
+    )
 
-#     correct_output = pl.DataFrame(
-#         {
-#             "fd_offset": [0, 0, 1, 1],
-#             "division": [0, 1, 0, 1],
-#             "mean_norm": [
-#                 np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
-#                 + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
-#                 np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
-#                 + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
-#                 np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
-#                 + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
-#                 np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
-#                 + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
-#             ],
-#         }
-#     )
+    correct_output = pl.DataFrame(
+        {
+            "fd_offset": [0, 0, 1, 1],
+            "division": [0, 1, 0, 1],
+            "score": [
+                np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
+                + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
+                np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
+                + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
+                np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
+                + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
+                np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
+                + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
+            ],
+        }
+    )
 
-#     result = eval.mean_norm_per_division_day(
-#         data, samples, samples_are_phi=True, p=1
-#     ).collect()
+    result = eval.mean_norm_per_division_day(
+        data, samples, samples_are_phi=True, p=1
+    ).collect()
 
-#     assert_frame_equal(
-#         result,
-#         correct_output,
-#         check_row_order=False,
-#         check_column_order=True,
-#         rtol=0,
-#         atol=0,
-#     )
-
-
-# def test_proportions_L1_energy_score(
-#     num_samples=100000, sample_variance=1.4, atol=0.05
-# ):
-#     r"""
-#     Test the estimate of the energy score of phi.
-
-#     The setup is as follows:
-#     - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
-#     - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
-#     - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
-#     - Check $$
-#         \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
-#         - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
-#       $$ as reported by `eval.proportions_energy_score`
-
-#     Note that our "forecasts" are not actually proportions, but independent normal
-#     random variables. This is so that the quantity can be computed analytically.
-#     """
-
-#     rng = default_rng()
-
-#     NUM_DAYS = 4
-#     NUM_DIVISIONS = 3
-#     NUM_LINEAGES = 2
-
-#     samples, data = _generate_fake_samples_and_data(
-#         rng,
-#         num_days=NUM_DAYS,
-#         num_divisions=NUM_DIVISIONS,
-#         num_lineages=NUM_LINEAGES,
-#         num_samples=num_samples,
-#         sample_variance=sample_variance,
-#     )
-
-#     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
-#     # its mean.
-#     # The mean absolute error of a normal random variable from its mean is
-#     # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
-#     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
-
-#     term1 = (
-#         np.sqrt(2 * sample_variance / np.pi)
-#         * NUM_DAYS
-#         * NUM_DIVISIONS
-#         * NUM_LINEAGES
-#     )
-
-#     # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
-#     # an independent copy of itself.
-#     # The mean absolute error of a normal random variable from an independent copy is
-#     # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
-#     # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
-
-#     term2 = (
-#         (2 * np.sqrt(sample_variance / np.pi))
-#         * NUM_DAYS
-#         * NUM_DIVISIONS
-#         * NUM_LINEAGES
-#     )
-
-#     assert np.isclose(
-#         eval.score(data, eval.energy_score_per_division_day, samples, samples_are_phi=True, p=1),
-#         term1 - 0.5 * term2,
-#         atol=atol,
-#     )
+    assert_frame_equal(
+        result,
+        correct_output,
+        check_row_order=False,
+        check_column_order=True,
+        rtol=0,
+        atol=0,
+    )
 
 
-# def test_proportions_L1_energy_score2():
-#     samples, data = _generate_fake_samples_and_data(
-#         None,
-#         num_days=2,
-#         num_divisions=2,
-#         num_lineages=2,
-#         num_samples=3,
-#         sample_variance=0,
-#     )
+def test_proportions_L1_energy_score(
+    num_samples=100000, sample_variance=1.4, atol=0.05
+):
+    r"""
+    Test the estimate of the energy score of phi.
 
-#     # Put in fixed values for counts and phi
-#     data = data.sort("fd_offset", "division", "lineage").with_columns(
-#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-#     )
+    The setup is as follows:
+    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
+    - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+    - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
+    - Check $$
+        \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
+        - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
+      $$ as reported by `eval.proportions_energy_score`
 
-#     samples = samples.sort(
-#         "fd_offset", "division", "sample_index", "lineage"
-#     ).with_columns(
-#         phi=pl.Series(
-#             [
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.1,
-#                 0.9,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#                 0.1,
-#                 0.9,
-#                 0.2,
-#                 0.8,
-#                 0.3,
-#                 0.7,
-#                 0.1,
-#                 0.9,
-#                 0.4,
-#                 0.6,
-#                 0.5,
-#                 0.5,
-#                 0.1,
-#                 0.9,
-#             ]
-#         ),
-#     )
+    Note that our "forecasts" are not actually proportions, but independent normal
+    random variables. This is so that the quantity can be computed analytically.
+    """
 
-#     correct_output = pl.DataFrame(
-#         {
-#             "fd_offset": [0, 0, 1, 1],
-#             "division": [0, 1, 0, 1],
-#             "energy_score": [
-#                 np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
-#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-#                 ).mean(),
-#                 np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
-#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-#                 ).mean(),
-#                 np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
-#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-#                 ).mean(),
-#                 np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
-#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-#                 ).mean()
-#                 - 0.5
-#                 * np.abs(
-#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-#                 ).mean(),
-#             ],
-#         }
-#     )
+    rng = default_rng()
 
-#     result = eval.energy_score_per_division_day(
-#         data, samples, samples_are_phi=True, p=1
-#     ).collect()
+    NUM_DAYS = 4
+    NUM_DIVISIONS = 3
+    NUM_LINEAGES = 2
 
-#     assert_frame_equal(
-#         result,
-#         correct_output,
-#         check_row_order=False,
-#         check_column_order=True,
-#     )
+    samples, data = _generate_fake_samples_and_data(
+        rng,
+        num_days=NUM_DAYS,
+        num_divisions=NUM_DIVISIONS,
+        num_lineages=NUM_LINEAGES,
+        num_samples=num_samples,
+        sample_variance=sample_variance,
+    )
+    print("++++++++++++++ SAMPLES ++++++++++++++")
+    print(samples.collect())
+    print("++++++++++++++ DATA ++++++++++++++")
+    print(data.collect())
+
+    # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
+    # its mean.
+    # The mean absolute error of a normal random variable from its mean is
+    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
+    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
+
+    term1 = (
+        np.sqrt(2 * sample_variance / np.pi)
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES
+    )
+
+    # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
+    # an independent copy of itself.
+    # The mean absolute error of a normal random variable from an independent copy is
+    # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
+    # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
+
+    term2 = (
+        (2 * np.sqrt(sample_variance / np.pi))
+        * NUM_DAYS
+        * NUM_DIVISIONS
+        * NUM_LINEAGES
+    )
+
+    assert np.isclose(
+        eval.score(
+            data,
+            eval.energy_score_per_division_day,
+            samples,
+            samples_are_phi=True,
+            p=1,
+        ),
+        term1 - 0.5 * term2,
+        atol=atol,
+    )
+
+
+def test_proportions_L1_energy_score2():
+    samples, data = _generate_fake_samples_and_data(
+        None,
+        num_days=2,
+        num_divisions=2,
+        num_lineages=2,
+        num_samples=3,
+        sample_variance=0,
+    )
+
+    # Put in fixed values for counts and phi
+    data = data.sort("fd_offset", "division", "lineage").with_columns(
+        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+    )
+
+    samples = samples.sort(
+        "fd_offset", "division", "sample_index", "lineage"
+    ).with_columns(
+        phi=pl.Series(
+            [
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.1,
+                0.9,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+                0.1,
+                0.9,
+                0.2,
+                0.8,
+                0.3,
+                0.7,
+                0.1,
+                0.9,
+                0.4,
+                0.6,
+                0.5,
+                0.5,
+                0.1,
+                0.9,
+            ]
+        ),
+    )
+
+    correct_output = pl.DataFrame(
+        {
+            "fd_offset": [0, 0, 1, 1],
+            "division": [0, 1, 0, 1],
+            "score": [
+                np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
+                + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+                ).mean(),
+                np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
+                + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+                ).mean(),
+                np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
+                + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+                ).mean(),
+                np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
+                + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+                ).mean()
+                - 0.5
+                * np.abs(
+                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+                ).mean(),
+            ],
+        }
+    )
+
+    result = eval.energy_score_per_division_day(
+        data, samples, samples_are_phi=True, p=1
+    ).collect()
+
+    assert_frame_equal(
+        result,
+        correct_output,
+        check_row_order=False,
+        check_column_order=True,
+    )

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -102,8 +102,8 @@ def test_proportions_mean_L1_norm(
 
     assert np.isclose(
         eval.score(
-            data,
             eval.mean_norm_per_division_day,
+            data,
             samples,
             samples_are_phi=True,
             p=1,
@@ -220,10 +220,6 @@ def test_proportions_L1_energy_score(
         num_samples=num_samples,
         sample_variance=sample_variance,
     )
-    print("++++++++++++++ SAMPLES ++++++++++++++")
-    print(samples.collect())
-    print("++++++++++++++ DATA ++++++++++++++")
-    print(data.collect())
 
     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
     # its mean.
@@ -253,8 +249,8 @@ def test_proportions_L1_energy_score(
 
     assert np.isclose(
         eval.score(
-            data,
             eval.energy_score_per_division_day,
+            data,
             samples,
             samples_are_phi=True,
             p=1,

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -1,7 +1,5 @@
 import numpy as np
-import polars as pl
 from numpy.random import default_rng
-from polars.testing import assert_frame_equal
 
 from linmod import eval
 from linmod.utils import expand_grid
@@ -36,13 +34,14 @@ def _generate_fake_samples_and_data(
 
     # Generate fake forecasts of population proportions
     samples = eval._merge_samples_and_data(
+        data,
         expand_grid(
             fd_offset=range(num_days),
             division=range(num_divisions),
             lineage=range(num_lineages),
             sample_index=range(num_samples),
         ),
-        data,
+        samples_are_phi=True,
     ).rename({"phi": "phi_mean"})
 
     samples = samples.with_columns(
@@ -91,7 +90,13 @@ def test_proportions_mean_L1_norm(
     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
 
     assert np.isclose(
-        eval.proportions_mean_norm(samples, data, p=1),
+        eval.score(
+            data,
+            eval.mean_norm_per_division_day,
+            samples,
+            samples_are_phi=True,
+            p=1,
+        ),
         np.sqrt(sample_variance * 2 / np.pi)
         * NUM_DAYS
         * NUM_DIVISIONS
@@ -100,248 +105,248 @@ def test_proportions_mean_L1_norm(
     )
 
 
-def test_proportions_mean_L1_norm2():
-    samples, data = _generate_fake_samples_and_data(
-        None,
-        num_days=2,
-        num_divisions=2,
-        num_lineages=2,
-        num_samples=2,
-        sample_variance=0,
-    )
+# def test_proportions_mean_L1_norm2():
+#     samples, data = _generate_fake_samples_and_data(
+#         None,
+#         num_days=2,
+#         num_divisions=2,
+#         num_lineages=2,
+#         num_samples=2,
+#         sample_variance=0,
+#     )
 
-    # Put in fixed values for counts and phi
-    data = data.sort("fd_offset", "division", "lineage").with_columns(
-        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-    )
+#     # Put in fixed values for counts and phi
+#     data = data.sort("fd_offset", "division", "lineage").with_columns(
+#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+#     )
 
-    samples = samples.sort(
-        "fd_offset", "division", "sample_index", "lineage"
-    ).with_columns(
-        phi=pl.Series(
-            [
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-            ]
-        ),
-    )
+#     samples = samples.sort(
+#         "fd_offset", "division", "sample_index", "lineage"
+#     ).with_columns(
+#         phi=pl.Series(
+#             [
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#             ]
+#         ),
+#     )
 
-    correct_output = pl.DataFrame(
-        {
-            "fd_offset": [0, 0, 1, 1],
-            "division": [0, 1, 0, 1],
-            "mean_norm": [
-                np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
-                + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
-                np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
-                + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
-                np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
-                + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
-                np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
-                + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
-            ],
-        }
-    )
+#     correct_output = pl.DataFrame(
+#         {
+#             "fd_offset": [0, 0, 1, 1],
+#             "division": [0, 1, 0, 1],
+#             "mean_norm": [
+#                 np.abs(np.array([0.2, 0.3]) - 1 / (1 + 2)).mean()
+#                 + np.abs(np.array([0.8, 0.7]) - 2 / (1 + 2)).mean(),
+#                 np.abs(np.array([0.4, 0.5]) - 3 / (3 + 4)).mean()
+#                 + np.abs(np.array([0.6, 0.5]) - 4 / (3 + 4)).mean(),
+#                 np.abs(np.array([0.2, 0.3]) - 5 / (5 + 6)).mean()
+#                 + np.abs(np.array([0.8, 0.7]) - 6 / (5 + 6)).mean(),
+#                 np.abs(np.array([0.4, 0.5]) - 7 / (7 + 8)).mean()
+#                 + np.abs(np.array([0.6, 0.5]) - 8 / (7 + 8)).mean(),
+#             ],
+#         }
+#     )
 
-    result = eval.proportions_mean_norm_per_division_day(
-        samples, data, p=1
-    ).collect()
+#     result = eval.mean_norm_per_division_day(
+#         data, samples, samples_are_phi=True, p=1
+#     ).collect()
 
-    assert_frame_equal(
-        result,
-        correct_output,
-        check_row_order=False,
-        check_column_order=True,
-        rtol=0,
-        atol=0,
-    )
-
-
-def test_proportions_L1_energy_score(
-    num_samples=100000, sample_variance=1.4, atol=0.05
-):
-    r"""
-    Test the estimate of the energy score of phi.
-
-    The setup is as follows:
-    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
-    - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
-    - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
-    - Check $$
-        \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
-        - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
-      $$ as reported by `eval.proportions_energy_score`
-
-    Note that our "forecasts" are not actually proportions, but independent normal
-    random variables. This is so that the quantity can be computed analytically.
-    """
-
-    rng = default_rng()
-
-    NUM_DAYS = 4
-    NUM_DIVISIONS = 3
-    NUM_LINEAGES = 2
-
-    samples, data = _generate_fake_samples_and_data(
-        rng,
-        num_days=NUM_DAYS,
-        num_divisions=NUM_DIVISIONS,
-        num_lineages=NUM_LINEAGES,
-        num_samples=num_samples,
-        sample_variance=sample_variance,
-    )
-
-    # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
-    # its mean.
-    # The mean absolute error of a normal random variable from its mean is
-    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
-    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
-
-    term1 = (
-        np.sqrt(2 * sample_variance / np.pi)
-        * NUM_DAYS
-        * NUM_DIVISIONS
-        * NUM_LINEAGES
-    )
-
-    # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
-    # an independent copy of itself.
-    # The mean absolute error of a normal random variable from an independent copy is
-    # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
-    # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
-
-    term2 = (
-        (2 * np.sqrt(sample_variance / np.pi))
-        * NUM_DAYS
-        * NUM_DIVISIONS
-        * NUM_LINEAGES
-    )
-
-    assert np.isclose(
-        eval.proportions_energy_score(samples, data, p=1),
-        term1 - 0.5 * term2,
-        atol=atol,
-    )
+#     assert_frame_equal(
+#         result,
+#         correct_output,
+#         check_row_order=False,
+#         check_column_order=True,
+#         rtol=0,
+#         atol=0,
+#     )
 
 
-def test_proportions_L1_energy_score2():
-    samples, data = _generate_fake_samples_and_data(
-        None,
-        num_days=2,
-        num_divisions=2,
-        num_lineages=2,
-        num_samples=3,
-        sample_variance=0,
-    )
+# def test_proportions_L1_energy_score(
+#     num_samples=100000, sample_variance=1.4, atol=0.05
+# ):
+#     r"""
+#     Test the estimate of the energy score of phi.
 
-    # Put in fixed values for counts and phi
-    data = data.sort("fd_offset", "division", "lineage").with_columns(
-        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-    )
+#     The setup is as follows:
+#     - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
+#     - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+#     - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
+#     - Check $$
+#         \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
+#         - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
+#       $$ as reported by `eval.proportions_energy_score`
 
-    samples = samples.sort(
-        "fd_offset", "division", "sample_index", "lineage"
-    ).with_columns(
-        phi=pl.Series(
-            [
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.1,
-                0.9,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.1,
-                0.9,
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.1,
-                0.9,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.1,
-                0.9,
-            ]
-        ),
-    )
+#     Note that our "forecasts" are not actually proportions, but independent normal
+#     random variables. This is so that the quantity can be computed analytically.
+#     """
 
-    correct_output = pl.DataFrame(
-        {
-            "fd_offset": [0, 0, 1, 1],
-            "division": [0, 1, 0, 1],
-            "energy_score": [
-                np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
-                + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-                ).mean(),
-                np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
-                + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-                ).mean(),
-                np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
-                + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-                ).mean(),
-                np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
-                + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-                ).mean(),
-            ],
-        }
-    )
+#     rng = default_rng()
 
-    result = eval.proportions_energy_score_per_division_day(
-        samples, data, p=1
-    ).collect()
+#     NUM_DAYS = 4
+#     NUM_DIVISIONS = 3
+#     NUM_LINEAGES = 2
 
-    assert_frame_equal(
-        result,
-        correct_output,
-        check_row_order=False,
-        check_column_order=True,
-    )
+#     samples, data = _generate_fake_samples_and_data(
+#         rng,
+#         num_days=NUM_DAYS,
+#         num_divisions=NUM_DIVISIONS,
+#         num_lineages=NUM_LINEAGES,
+#         num_samples=num_samples,
+#         sample_variance=sample_variance,
+#     )
+
+#     # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
+#     # its mean.
+#     # The mean absolute error of a normal random variable from its mean is
+#     # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
+#     # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
+
+#     term1 = (
+#         np.sqrt(2 * sample_variance / np.pi)
+#         * NUM_DAYS
+#         * NUM_DIVISIONS
+#         * NUM_LINEAGES
+#     )
+
+#     # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
+#     # an independent copy of itself.
+#     # The mean absolute error of a normal random variable from an independent copy is
+#     # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
+#     # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
+
+#     term2 = (
+#         (2 * np.sqrt(sample_variance / np.pi))
+#         * NUM_DAYS
+#         * NUM_DIVISIONS
+#         * NUM_LINEAGES
+#     )
+
+#     assert np.isclose(
+#         eval.score(data, eval.energy_score_per_division_day, samples, samples_are_phi=True, p=1),
+#         term1 - 0.5 * term2,
+#         atol=atol,
+#     )
+
+
+# def test_proportions_L1_energy_score2():
+#     samples, data = _generate_fake_samples_and_data(
+#         None,
+#         num_days=2,
+#         num_divisions=2,
+#         num_lineages=2,
+#         num_samples=3,
+#         sample_variance=0,
+#     )
+
+#     # Put in fixed values for counts and phi
+#     data = data.sort("fd_offset", "division", "lineage").with_columns(
+#         count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
+#     )
+
+#     samples = samples.sort(
+#         "fd_offset", "division", "sample_index", "lineage"
+#     ).with_columns(
+#         phi=pl.Series(
+#             [
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.1,
+#                 0.9,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#                 0.1,
+#                 0.9,
+#                 0.2,
+#                 0.8,
+#                 0.3,
+#                 0.7,
+#                 0.1,
+#                 0.9,
+#                 0.4,
+#                 0.6,
+#                 0.5,
+#                 0.5,
+#                 0.1,
+#                 0.9,
+#             ]
+#         ),
+#     )
+
+#     correct_output = pl.DataFrame(
+#         {
+#             "fd_offset": [0, 0, 1, 1],
+#             "division": [0, 1, 0, 1],
+#             "energy_score": [
+#                 np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
+#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+#                 ).mean(),
+#                 np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
+#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+#                 ).mean(),
+#                 np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
+#                 + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
+#                 ).mean(),
+#                 np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
+#                 + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
+#                 ).mean()
+#                 - 0.5
+#                 * np.abs(
+#                     np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
+#                 ).mean(),
+#             ],
+#         }
+#     )
+
+#     result = eval.energy_score_per_division_day(
+#         data, samples, samples_are_phi=True, p=1
+#     ).collect()
+
+#     assert_frame_equal(
+#         result,
+#         correct_output,
+#         check_row_order=False,
+#         check_column_order=True,
+#     )

--- a/retrospective-forecasting/config/early-21L.yaml
+++ b/retrospective-forecasting/config/early-21L.yaml
@@ -56,7 +56,10 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/early-21L
 
+  # Number of posterior samples for which predictive counts will be generated
+  num_post_pred_samps: 500
+
   # How should forecasts be evaluated?
   metrics:
-    - proportions_mean_norm
-    - proportions_energy_score
+    - mean_norm
+    - energy_score

--- a/retrospective-forecasting/config/late-21L.yaml
+++ b/retrospective-forecasting/config/late-21L.yaml
@@ -56,7 +56,10 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/late-21L
 
+  # Number of posterior samples for which predictive counts will be generated
+  num_post_pred_samps: 500
+
   # How should forecasts be evaluated?
   metrics:
-    - proportions_mean_norm
-    - proportions_energy_score
+    - mean_norm
+    - energy_score

--- a/retrospective-forecasting/config/mid-21L.yaml
+++ b/retrospective-forecasting/config/mid-21L.yaml
@@ -56,7 +56,10 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/mid-21L
 
+  # Number of posterior samples for which predictive counts will be generated
+  num_post_pred_samps: 500
+
   # How should forecasts be evaluated?
   metrics:
-    - proportions_mean_norm
-    - proportions_energy_score
+    - mean_norm
+    - energy_score

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import shutil
 import sys
 
 import jax
@@ -40,12 +39,6 @@ model_data = pl.read_csv(
 # Fit each model
 
 forecast_dir = ValidPath(config["forecasting"]["save_dir"])
-
-if forecast_dir.exists():
-    print_message("Removing existing output directory and all contents.")
-    shutil.rmtree(forecast_dir)
-
-forecast_dir.mkdir()
 
 for model_name in config["forecasting"]["models"]:
     print_message(f"Fitting {model_name} model...")

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -46,7 +46,7 @@ for model_name in config["forecasting"]["models"]:
     model = model_class(model_data)
 
     mcmc = MCMC(
-        NUTS(model.numpyro_model),
+        NUTS(model.numpyro_model, dense_mass=True),
         num_samples=config["forecasting"]["mcmc"]["samples"],
         num_warmup=config["forecasting"]["mcmc"]["warmup"],
         num_chains=config["forecasting"]["mcmc"]["chains"],


### PR DESCRIPTION
This is part PR, part investigation.

## Background

As noted in #47, the priors I implemented in #41 didn't match the way we handle time. I calibrated priors in terms of days, our model was working in terms of standardized time (time with mean 0 and variance 1). This model worked, in that MCMC ran acceptably, but did not work, in that the priors were too informative and the posteriors of the independent divisions model were too strongly influenced.

## Previous work

Simply removing the standardization on time, however, led to less than stellar MCMC mixing of the Independent Divisions model, and pathological behavior of the Hierarchical Divisions model.

Previous experimentation suggested that standardizing time improved MCMC mixing. However, attempting to mix-and-match scales (set priors on real time, infer on standardized, #55) also led to apparently pathologically bad mixing. In hindsight, this is likely because the transformation induces a strong correlation, where we can otherwise parameterize things more orthogonally.

## This PR

### TL;DR 
We can make MCMC work by using a dense mass matrix instead of a diagonal mass matrix.

I renamed the `HierarchicalDivisonModel` the `HierarchicalCorrelatedDeviationsModel` and implemented a MVN-free, simpler `HierarchicalDivisonModel`. Both of these have "dynamic pooling" as below, and have one small parameter removed from the previous `HierarchicalDivisonModel`.

### What I tried

To debug the hierarchical model, I made a version which could be set to be mathematically equivalent to the Independent model. This required a minor simplification, removing the free parameter `sigma_beta_0` (a scalar on intercept variances allowing some lineages to vary more in intercepts than others), and was facilitated by removing the correlated deviations in slopes (where the independent model was only recovered in a limit as we take a fixed hyperparameter to infinity).

This enabled me to rewrite the model as described below. Using that, I was able to get a version of the Hierarchical model which could have parameters fixed to recapitulate the Independent Divisions model. I found that when I re-wrote this model to use plates (plating first over lineage, then division) I could obtain MCMC which mixed as well as the Independent Divisions model. Which is to say, not _well_, but not so poorly that we couldn't just run it longer and obtain satisfactory convergence diagnostics.

As I increased the strength of the pooling (either letting the model infer it, where it is very strong, or fixing it to 0.5, which is what we implicitly had before), mixing got worse. I tried using `numpyro.infer.reparam.LocScaleReparam` but this did not appear to have any effect. I imagine that is because the model was already written in the space that parameterization seeks (location 0, common scale 1).

I then tried altering the NUTS settings to use a dense mass matrix, which can account for posterior correlations in parameters. With this turned on, both the Independent and stripped-down Hierarchical models work much better, if slower. (I think the efficiency is worth the tradeoff, such that to get equivalent ESS we'd need to spend more time running the model. But I did not check.) 

Lastly, I tried adding back in the correlated deviations of the slopes. With a dense mass matrix, this model can also be sampled.

I did not try adding back `sigma_beta_0` as while it is perfectly sensible, the uncorrelated-deviations, dynamic pooling hierarchical model seems to be the simplest starting point for pooled model development and we might as well test what works and doesn't in comparison.

### What I think I learned

Partial pooling makes the posterior geometry gnarlier, plates can be useful where applicable, noncentered parameterizations are good, and a good (bad) prior can be bad (good) for mixing.

### Dynamic pooling
All slopes and intercepts here are taken to be on the logit scale and absent a reference category, as we have been doing.

For a model with uncorrelated slope deviations, for location $g$ and lineage $\ell$, both intercepts $\boldsymbol{\beta}\_0$ and slopes $\boldsymbol{\beta}\_1$ can be written as
```math
\beta_{g \ell} := \mu_{\ell} +Z_{g \ell}
```
with
```math
\mu_{\ell} \sim \text{Normal}(0, \sigma_{\mu}^2)
```
and
```math
Z_{g \ell} \sim \text{Normal}(0, \sigma_Z^2)
```
and fixed $\sigma$.


The marginal prior variance is $\text{V}[\beta_{g \ell}] = \text{V}[\mu_{\ell}]  + \text{V}[Z_{g \ell}] = \sigma_Z + \sigma_{\mu}$. 

As #41 shows, it is really $\text{V}[\beta_{g \ell}]$ that we have any intuition about.

We can recover the Independent Divisions model by fixing $\mu_{\ell}$ to 0, such that all of the variance in $\beta_{g \ell}$ is due to $Z_{g \ell}$. We can also imagine on the other side a fully pooled model, in which  all of the variance in $\beta_{g \ell}$ is due to $\mu_{\ell}$. The "strength" of the pooling then can be described by how much of the variance comes from either component, which suggests that we can in fact re-write all three models (unpooled, fully pooled, partially pooled) as
```math
\beta_{g \ell} := \mu_{\ell} + Z_{g \ell}
```
with
```math
\mu_{\ell} \sim \text{Normal}(0, \rho \sigma_{\beta}^2)
```
and
```math
Z_{g \ell} \sim \text{Normal}(0, (1 - \rho) \sigma_{\beta}^2)
```
and fixed $\sigma_{\beta}$.

We can set $\rho = 1$ to get a fully pooled model, let $\rho$ be inferred, or fix $\rho = 0$ to recover the Independent Divisions model. I have implemented this model with separate pooling for the slopes and intercepts.

We can also apply this framework to the original Hierarchical formulation where differences in slopes from the grand mean are correlated. We have a number of length $\ell$ vectors instead of scalars (bold is not rendering for some reason)
```math
\boldsymbol{\beta}_g = \boldsymbol{\mu} + \boldsymbol{Z}_{g}
```
with (as in the non-correlated model)
```math
\mu_{\ell} \sim \text{Normal}(0, \rho \sigma_{\beta}^2)
```
and
```math
\boldsymbol{Z}_{g} \sim \text{MultivariateNormal}(0, \Sigma)
```
where $\Sigma = \text{diag}((1 - \rho) \sigma_{\beta}, L) \mathbf{R} \text{diag}((1 - \rho) \sigma_{\beta}, L)$, $R$ is a correlation matrix, $\text{diag}((1 - \rho) \sigma_{\beta}, L)$ is an $L x L$ diagonal matrix with all elements equal to $(1 - \rho) \sigma_{\beta}$, and
```math
R \sim \text{LKJ}(\eta)
```
As we were already working with our covariance matrix decomposed into a diagonal matrix of standard deviations and a correlation matrix, the $\rho, (1 - \rho)$ formulation is plug and play here too.