### PR TITLE
Unstandardized time

### DIFF
--- a/linmod/models/models.py
+++ b/linmod/models/models.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+
 import jax.numpy as jnp
 import numpy as np
 import numpyro

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -17,7 +17,7 @@ class GeographicAggregator(ABC):
     @abstractmethod
     def __call__(
         self, forecast: pl.DataFrame, geo_map: dict[str, str], **kwargs
-    ) -> pl.LazyFrame:
+    ) -> pl.DataFrame:
         raise NotImplementedError()
 
 
@@ -48,7 +48,7 @@ class InfectionWeightedAggregator(GeographicAggregator):
 
     def __call__(
         self, forecast: pl.DataFrame, geo_map: dict[str, str], **kwargs
-    ) -> pl.LazyFrame:
+    ) -> pl.DataFrame:
         pop_size = kwargs.get(
             "pop_size",
             pl.DataFrame(

--- a/retrospective-forecasting/config/early-21L.yaml
+++ b/retrospective-forecasting/config/early-21L.yaml
@@ -36,8 +36,9 @@ forecasting:
 
   # MCMC configuration
   mcmc:
-    warmup: 2500
-    samples: 500
+    warmup: 3000
+    samples: 3000
+    thinning: 3
     chains: 4
     convergence:
       # one of: "all" or "failing" to write a parquet of ESS and PSRF
@@ -46,11 +47,9 @@ forecasting:
       # Should diagnostic plots for all reported parameters be made?
       plot: True
       # ESS below this are considered bad
-      ess_cutoff: 625
+      ess_cutoff: 500
       # PSRF above this are considered bad
-      psrf_cutoff: 1.005
-      # Parameters containing fixed quantities have no variability and cause 0/0 errors
-      ignore_nan_in: ["Omega_decomposition"]
+      psrf_cutoff: 1.01
 
   # Settings for HHS region, population-weighted aggregate forecasts
   survey:

--- a/retrospective-forecasting/config/late-21L.yaml
+++ b/retrospective-forecasting/config/late-21L.yaml
@@ -36,8 +36,9 @@ forecasting:
 
   # MCMC configuration
   mcmc:
-    warmup: 2500
-    samples: 500
+    warmup: 3000
+    samples: 3000
+    thinning: 3
     chains: 4
     convergence:
       # one of: "all" or "failing" to write a parquet of ESS and PSRF
@@ -46,11 +47,9 @@ forecasting:
       # Should diagnostic plots for all reported parameters be made?
       plot: True
       # ESS below this are considered bad
-      ess_cutoff: 625
+      ess_cutoff: 500
       # PSRF above this are considered bad
-      psrf_cutoff: 1.005
-      # Parameters containing fixed quantities have no variability and cause 0/0 errors
-      ignore_nan_in: ["Omega_decomposition"]
+      psrf_cutoff: 1.01
 
   # Settings for HHS region, population-weighted aggregate forecasts
   survey:

--- a/retrospective-forecasting/config/mid-21L.yaml
+++ b/retrospective-forecasting/config/mid-21L.yaml
@@ -36,8 +36,9 @@ forecasting:
 
   # MCMC configuration
   mcmc:
-    warmup: 2500
-    samples: 500
+    warmup: 3000
+    samples: 3000
+    thinning: 3
     chains: 4
     convergence:
       # one of: "all" or "failing" to write a parquet of ESS and PSRF
@@ -46,11 +47,9 @@ forecasting:
       # Should diagnostic plots for all reported parameters be made?
       plot: True
       # ESS below this are considered bad
-      ess_cutoff: 625
+      ess_cutoff: 500
       # PSRF above this are considered bad
-      psrf_cutoff: 1.005
-      # Parameters containing fixed quantities have no variability and cause 0/0 errors
-      ignore_nan_in: ["Omega_decomposition"]
+      psrf_cutoff: 1.01
 
   # Settings for HHS region, population-weighted aggregate forecasts
   survey:

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -51,125 +51,136 @@ if forecast_dir.exists():
 
 forecast_dir.mkdir()
 
-for model_name in config["forecasting"]["models"]:
-    print_message(f"Fitting {model_name} model...")
-    model_class = linmod.models.__dict__[model_name]
-    model = model_class(model_data)
-
-    mcmc = MCMC(
-        NUTS(model.numpyro_model, dense_mass=model.dense_mass()),
-        num_samples=config["forecasting"]["mcmc"]["samples"],
-        num_warmup=config["forecasting"]["mcmc"]["warmup"],
-        num_chains=config["forecasting"]["mcmc"]["chains"],
-        thinning=config["forecasting"]["mcmc"]["thinning"],
-    )
-    mcmc.run(jax.random.key(0))
-
-    try:
-        convergence = linmod.models.get_convergence(
-            mcmc, ignore_nan_in=model.ignore_nan_in(), drop_ignorable_nan=False
-        )
-
-        if (
-            config["forecasting"]["mcmc"]["convergence"]["report_mode"]
-            == "failing"
-        ):
-            convergence = convergence.filter(
-                (
-                    pl.col("n_eff")
-                    < config["forecasting"]["mcmc"]["convergence"][
-                        "ess_cutoff"
-                    ]
-                )
-                | (
-                    pl.col("r_hat")
-                    > config["forecasting"]["mcmc"]["convergence"][
-                        "psrf_cutoff"
-                    ]
-                )
-            )
-        convergence.write_parquet(
-            forecast_dir / f"convergence_{model_name}.parquet"
-        )
-
-        if (
-            config["forecasting"]["mcmc"]["convergence"]["plot"]
-            and convergence.shape[0] > 0
-        ):
-            plot_dir = forecast_dir / ("convergence_" + model_name)
-            plots = linmod.models.plot_convergence(mcmc, convergence["param"])
-            for plot, par in zip(plots, convergence["param"].to_list()):
-                plot.save(plot_dir / (par + ".png"), verbose=False)
-
-            # Try to free up some memory
-            del plots, plot
-
-        del convergence
-
-    except Exception as e:
-        print_message("An error occurred while checking convergence:")
-        print_message(e)
-
-    forecast = model.create_forecasts(
-        mcmc,
-        np.arange(
-            config["data"]["horizon"]["lower"],
-            config["data"]["horizon"]["upper"] + 1,
-        ),
-    )
-
-    forecast.write_parquet(forecast_dir / f"forecasts_{model_name}.parquet")
-
-    if config["forecasting"]["survey"]["make"]:
-        # Take missing divisions out of map
-        hhs_map = {
-            div: linmod.data.hhs_regions[div]
-            for div in forecast["division"].unique()
-        }
-        hhs_region_forecast = linmod.models.InfectionWeightedAggregator()(
-            forecast,
-            hhs_map,
-            pop_sizes=pl.read_csv(
-                config["forecasting"]["survey"]["pop_sizes"]
-            ),
-        )
-        hhs_region_forecast.write_parquet(
-            forecast_dir / f"hhs_region_forecasts_{model_name}.parquet"
-        )
-
-        if config["forecasting"]["survey"]["plot"]:
-            plot_forecast(hhs_region_forecast).save(
-                forecast_dir
-                / "visualizations"
-                / f"hhs_region_forecasts_{model_name}.png",
-                width=25,
-                height=15,
-                dpi=200,
-                verbose=False,
-            )
-
-    print_message("Done.")
-
-    # Try to free up some memory
-    del model, mcmc, forecast
-
-
-# Load the full evaluation dataset
-
-eval_data = pl.read_parquet(config["data"]["save_file"]["eval"])
-
-viz_data = eval_data.filter(
-    pl.col("lineage").is_in(model_data["lineage"].unique()),
-    pl.col("fd_offset") > 0,
-)
-
-# Evaluate each model
-eval_dir = ValidPath(config["evaluation"]["save_dir"])
-
-scores = []
-plot_script_file = f"plot_all_{eval_dir.name}.sh"
+plot_script_file = f"plot_all_{forecast_dir.name}.sh"
 with open(plot_script_file, "w") as plot_script:
     plot_script.write("#/usr/bin/sh\n")
+    for model_name in config["forecasting"]["models"]:
+        print_message(f"Fitting {model_name} model...")
+        model_class = linmod.models.__dict__[model_name]
+        model = model_class(model_data)
+
+        mcmc = MCMC(
+            NUTS(model.numpyro_model, dense_mass=model.dense_mass()),
+            num_samples=config["forecasting"]["mcmc"]["samples"],
+            num_warmup=config["forecasting"]["mcmc"]["warmup"],
+            num_chains=config["forecasting"]["mcmc"]["chains"],
+            thinning=config["forecasting"]["mcmc"]["thinning"],
+        )
+        mcmc.run(jax.random.key(0))
+
+        try:
+            convergence = linmod.models.get_convergence(
+                mcmc,
+                ignore_nan_in=model.ignore_nan_in(),
+                drop_ignorable_nan=False,
+            )
+
+            if (
+                config["forecasting"]["mcmc"]["convergence"]["report_mode"]
+                == "failing"
+            ):
+                convergence = convergence.filter(
+                    (
+                        pl.col("n_eff")
+                        < config["forecasting"]["mcmc"]["convergence"][
+                            "ess_cutoff"
+                        ]
+                    )
+                    | (
+                        pl.col("r_hat")
+                        > config["forecasting"]["mcmc"]["convergence"][
+                            "psrf_cutoff"
+                        ]
+                    )
+                )
+            convergence.write_parquet(
+                forecast_dir / f"convergence_{model_name}.parquet"
+            )
+
+            if (
+                config["forecasting"]["mcmc"]["convergence"]["plot"]
+                and convergence.shape[0] > 0
+            ):
+                plot_dir = forecast_dir / ("convergence_" + model_name)
+                plots = linmod.models.plot_convergence(
+                    mcmc, convergence["param"]
+                )
+                for plot, par in zip(plots, convergence["param"].to_list()):
+                    plot.save(plot_dir / (par + ".png"), verbose=False)
+
+                # Try to free up some memory
+                del plots, plot
+
+            del convergence
+
+        except Exception as e:
+            print_message("An error occurred while checking convergence:")
+            print_message(e)
+
+        forecast = model.create_forecasts(
+            mcmc,
+            np.arange(
+                config["data"]["horizon"]["lower"],
+                config["data"]["horizon"]["upper"] + 1,
+            ),
+        )
+
+        forecast.write_parquet(
+            forecast_dir / f"forecasts_{model_name}.parquet"
+        )
+
+        if config["forecasting"]["survey"]["make"]:
+            print_message("Aggregating to HHS regions")
+            # Take missing divisions out of map
+            hhs_map = {
+                div: linmod.data.hhs_regions[div]
+                for div in forecast["division"].unique()
+            }
+            hhs_region_forecast = linmod.models.InfectionWeightedAggregator()(
+                forecast,
+                hhs_map,
+                pop_sizes=pl.read_csv(
+                    config["forecasting"]["survey"]["pop_sizes"]
+                ),
+            )
+            agg_forecast_path = (
+                forecast_dir / f"hhs_region_forecasts_{model_name}.parquet"
+            )
+            hhs_region_forecast.write_parquet(agg_forecast_path)
+
+            if config["forecasting"]["survey"]["plot"]:
+                png = (
+                    forecast_dir
+                    / "visualizations"
+                    / f"hhs_region_forecasts_{model_name}.png"
+                )
+                plot_script.write(
+                    (
+                        "python3 -m linmod.visualize "
+                        f"-f {agg_forecast_path} "
+                        f"-p {png} "
+                        "-t nodata\n"
+                    )
+                )
+
+        print_message("Done.")
+
+        # Try to free up some memory
+        del model, mcmc, forecast
+
+    # Load the full evaluation dataset
+
+    eval_data = pl.read_parquet(config["data"]["save_file"]["eval"])
+
+    viz_data = eval_data.filter(
+        pl.col("lineage").is_in(model_data["lineage"].unique()),
+        pl.col("fd_offset") > 0,
+    )
+
+    # Evaluate each model
+    eval_dir = ValidPath(config["evaluation"]["save_dir"])
+
+    scores = []
     for metric_name in config["evaluation"]["metrics"]:
         metric_function = linmod.eval.__dict__[metric_name]
 

--- a/retrospective-forecasting/run_all.sh
+++ b/retrospective-forecasting/run_all.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
+echo "Running and evaluating models for all configs"
 for conf in `ls config/`; do ./main.py config/$conf; done
+
+echo "Plotting results for all models for all configs"
+for plotsh in `ls plot_all_*`; do sh $plotsh; done
+rm plot_all_*


### PR DESCRIPTION
The goal of this PR was to have models that work on unstandardized time with appropriate priors. This entailed two interrelated matters.

## Models and MCMC

I un-standardized time, resolving #47. I also added an abstract class from which all models now descend. Models now additionally know some things about how their MCMC should be run and diagnosed.

### MCMC
I altered our MCMC settings and convergence diagnostic thresholds. We now
- Run many more iterations
- Thin (save fewer iterations, configurable by config)
- Have somewhat lower convergence standards (not egregiously low, in my experience)

### Mass matrices
I re-wrote the `IndependentDivisionsModel` and the `HierarchicalDivisionsModel` to use a loop over states. This significantly slows model compilation, but in return it allows our models to mix sufficiently (ESS per sample is drastically higher and lower variance in testing).

The mixing gain is because this loop allows us to use a block-diagonal mass matrix, which adapts to correlations in each state in the slopes and intercepts. A full mass matrix worked well most of the time but occasionally crashed entire chains (this sunk #58). This simpler structure appears to be learnable and capture sufficient correlation even in the hierarchical model.

Via `.dense_mass()`, each model can now return a value appropriate for passing to the `dense_mass` argument of NumPyro's NUTS implementation.

### Other model changes

I simplified the `HierarchicalDivisionsModel` to remove the multivariate distribution on how slopes deviate from the overall mean term (slopes, like intercepts, now deviate independently across variants). This was killing MCMC performance and preliminary testing suggests that in general the models like very similar slopes across regions anyways. A loop-version of the previous model is available as the `CorrelatedDeviationsModel`, but it is not enabled in the configs in `retrospective-forecasting`.

I also made it easier to change the "strength" of pooling as a user setting, separately for slopes and intercepts. This term is in [0,1] and allocates variance to the global mean term, with one minus this amount going to local deviations around that mean. Thus, 0 is complete independence, and 1 is complete pooling. I left the intercept at the previous implicit value of 0.5, but increased the slope default to 0.75, as preliminary testing suggested larger values are appropriate.

## Pipeline
The increased model iterations provoked a memory leak, or something that looks a lot like one. This caused both evaluation and plotting to fail in `retrospective-forecasting`. It was apparently induced by the plotting but interacted with upstream evaluation in polars dataframes in ways I cannot comprehend.

To keep our ability to plot things, I therefore had to refactor the pipeline. The changes to main look bigger than they are, the short version is that, in order to push all the plotting to separate system `python` calls, I
- Track _what_ the pipeline wants to plot, by writing, from `retrospective-forecasting/main.py` a second bash script which the primary loop (`run_all.sh`) calls after it completes the modeling and evaluating. It subsequently deletes the second bash script.
- In order for this to work, I gave `linmod.visualize` a `__main__` method and arg parsing, so that it can be called on the filepaths to the correct inputs, rather than calling the in-python viz function with python objects.

## Recreational out-of-scope type hinting
I cleaned up a handful of places where type-hinting was either wrong, or unhappy.