### PR TITLE
Ensuring integrity of DataFrames for observed counts and model forecasts

### DIFF
--- a/linmod/data.py
+++ b/linmod/data.py
@@ -226,17 +226,17 @@ class CountsFrame(pl.DataFrame):
         return cls(pl.read_parquet(*args, **kwargs))
 
     def validate(self):
-        assert self.REQUIRED_COLUMNS.issubset(self.columns), (
-            f"Missing required columns: ({', '.join(self.REQUIRED_COLUMNS - set(self.columns))})"
-        )
+        assert self.REQUIRED_COLUMNS.issubset(
+            self.columns
+        ), f"Missing required columns: ({', '.join(self.REQUIRED_COLUMNS - set(self.columns))})"
 
-        assert self.null_count().sum_horizontal().item() == 0, (
-            "Null values detected in the dataset."
-        )
+        assert (
+            self.null_count().sum_horizontal().item() == 0
+        ), "Null values detected in the dataset."
 
-        assert self["count"].dtype.is_integer(), (
-            "Count column must be an integer type."
-        )
+        assert self[
+            "count"
+        ].dtype.is_integer(), "Count column must be an integer type."
 
 
 def main(cfg: Optional[dict]):

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -230,13 +230,13 @@ class CountsFrame(pl.DataFrame):
         if hasattr(super(), "validate"):
             super().validate(*args, **kwargs)
 
-        assert self.REQUIRED_COLUMNS.issubset(self.columns), (
-            f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
-        )
+        assert self.REQUIRED_COLUMNS.issubset(
+            self.columns
+        ), f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
 
-        assert self.null_count().sum_horizontal().item() == 0, (
-            "Null values detected in the dataset."
-        )
+        assert (
+            self.null_count().sum_horizontal().item() == 0
+        ), "Null values detected in the dataset."
 
         assert self["count"].dtype in {
             pl.Int8,

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -232,7 +232,7 @@ class CountsFrame(pl.DataFrame):
 
         assert self.REQUIRED_COLUMNS.issubset(
             self.columns
-        ), f"Missing at least one required column ({", ".join(self.REQUIRED_COLUMNS)})."
+        ), f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
 
         assert (
             self.null_count().sum_horizontal().item() == 0

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -230,13 +230,24 @@ class CountsFrame(pl.DataFrame):
         if hasattr(super(), "validate"):
             super().validate(*args, **kwargs)
 
-        assert self.REQUIRED_COLUMNS.issubset(
-            self.columns
-        ), f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
+        assert self.REQUIRED_COLUMNS.issubset(self.columns), (
+            f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
+        )
 
-        assert (
-            self.null_count().sum_horizontal().item() == 0
-        ), "Null values detected in the dataset."
+        assert self.null_count().sum_horizontal().item() == 0, (
+            "Null values detected in the dataset."
+        )
+
+        assert self["count"].dtype in {
+            pl.Int8,
+            pl.Int16,
+            pl.Int32,
+            pl.Int64,
+            pl.UInt8,
+            pl.UInt16,
+            pl.UInt32,
+            pl.UInt64,
+        }, "Count column must be an integer type."
 
 
 def main(cfg: Optional[dict]):
@@ -257,9 +268,10 @@ def main(cfg: Optional[dict]):
     if config["data"]["redownload"] or not cache_path.exists():
         print_message("Downloading...", end="")
 
-        with urlopen(config["data"]["source"]) as response, cache_path.open(
-            "wb"
-        ) as out_file:
+        with (
+            urlopen(config["data"]["source"]) as response,
+            cache_path.open("wb") as out_file,
+        ):
             if parsed_url.path.endswith(".gz"):
                 with lzma.open(response) as in_file:
                     out_file.write(in_file.read())
@@ -288,10 +300,10 @@ def main(cfg: Optional[dict]):
     )
 
     horizon_lower_date = forecast_date.dt.offset_by(
-        f'{config["data"]["horizon"]["lower"]}d'
+        f"{config['data']['horizon']['lower']}d"
     )
     horizon_upper_date = forecast_date.dt.offset_by(
-        f'{config["data"]["horizon"]["upper"]}d'
+        f"{config['data']['horizon']['upper']}d"
     )
 
     model_all_lineages = len(config["data"]["lineages"]) == 0

--- a/linmod/models/models.py
+++ b/linmod/models/models.py
@@ -7,6 +7,7 @@ import numpyro.distributions as dist
 import polars as pl
 
 from ..utils import expand_grid, pl_softmax
+from .utils import ForecastFrame
 
 
 class MultinomialModel(ABC):
@@ -35,12 +36,12 @@ class MultinomialModel(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def create_forecasts(self, mcmc, fd_offsets) -> pl.DataFrame:
+    def create_forecasts(self, mcmc, fd_offsets) -> ForecastFrame:
         """
-        Generate polars.DataFrame with: sample index, fd_offset, division, lineage, true proportion..
+        Generate a data frame of forecasted population-level proportions.
 
         mcmc:          The MCMC.
-        fd_offsets:    The (relative) days on which to generate forecasted true proportions.
+        fd_offsets:    The (relative) days on which to generate forecasted proportions.
         """
         raise NotImplementedError
 
@@ -205,7 +206,7 @@ class HierarchicalDivisionsModel(MultinomialModel):
             .drop("chain", "iteration")
         )
 
-        return (
+        return ForecastFrame(
             expand_grid(
                 sample_index=parameter_samples["sample_index"].unique(),
                 fd_offset=fd_offsets,
@@ -419,7 +420,7 @@ class IndependentDivisionsModel(MultinomialModel):
             .drop("chain", "iteration")
         )
 
-        return (
+        return ForecastFrame(
             expand_grid(
                 sample_index=parameter_samples["sample_index"].unique(),
                 fd_offset=fd_offsets,
@@ -526,7 +527,7 @@ class BaselineModel(MultinomialModel):
             .drop("chain", "iteration")
         )
 
-        return (
+        return ForecastFrame(
             expand_grid(
                 sample_index=parameter_samples["sample_index"].unique(),
                 fd_offset=fd_offsets,

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -39,17 +39,17 @@ class ForecastFrame(pl.DataFrame):
         if hasattr(super(), "validate"):
             super().validate(*args, **kwargs)
 
-        assert self.REQUIRED_COLUMNS.issubset(self.columns), (
-            f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
-        )
+        assert self.REQUIRED_COLUMNS.issubset(
+            self.columns
+        ), f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
 
         proportion_sums = self.group_by(
             "sample_index", "fd_offset", "division"
         ).agg(pl.sum("phi"))
 
-        assert ((proportion_sums["phi"] - 1).abs() < 1e-3).all(), (
-            f"Lineage proportions do not sum to 1."
-        )
+        assert (
+            (proportion_sums["phi"] - 1).abs() < 1e-3
+        ).all(), f"Lineage proportions do not sum to 1."
 
 
 class GeographicAggregator(ABC):
@@ -113,17 +113,15 @@ class InfectionWeightedAggregator(GeographicAggregator):
 
         assert set(geo_map.keys()).issubset(
             set(forecast["division"].unique())
-        ), (
-            'All divisions in `geo_map.keys()` must be in `forecast["division"].'
-        )
+        ), 'All divisions in `geo_map.keys()` must be in `forecast["division"].'
 
-        assert set(geo_map.keys()).issubset(set(pop_size["division"])), (
-            'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
-        )
+        assert set(geo_map.keys()).issubset(
+            set(pop_size["division"])
+        ), 'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
 
-        assert set(geo_map.keys()).issubset(set(prop_infected["division"])), (
-            'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
-        )
+        assert set(geo_map.keys()).issubset(
+            set(prop_infected["division"])
+        ), 'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
 
         weights = (
             pop_size.join(

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -39,9 +39,17 @@ class ForecastFrame(pl.DataFrame):
         if hasattr(super(), "validate"):
             super().validate(*args, **kwargs)
 
-        assert self.REQUIRED_COLUMNS.issubset(
-            self.columns
-        ), f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
+        assert self.REQUIRED_COLUMNS.issubset(self.columns), (
+            f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
+        )
+
+        proportion_sums = self.group_by(
+            "sample_index", "fd_offset", "division"
+        ).agg(pl.sum("phi"))
+
+        assert ((proportion_sums["phi"] - 1).abs() < 1e-3).all(), (
+            f"Lineage proportions do not sum to 1."
+        )
 
 
 class GeographicAggregator(ABC):
@@ -105,15 +113,17 @@ class InfectionWeightedAggregator(GeographicAggregator):
 
         assert set(geo_map.keys()).issubset(
             set(forecast["division"].unique())
-        ), 'All divisions in `geo_map.keys()` must be in `forecast["division"].'
+        ), (
+            'All divisions in `geo_map.keys()` must be in `forecast["division"].'
+        )
 
-        assert set(geo_map.keys()).issubset(
-            set(pop_size["division"])
-        ), 'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
+        assert set(geo_map.keys()).issubset(set(pop_size["division"])), (
+            'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
+        )
 
-        assert set(geo_map.keys()).issubset(
-            set(prop_infected["division"])
-        ), 'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
+        assert set(geo_map.keys()).issubset(set(prop_infected["division"])), (
+            'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
+        )
 
         weights = (
             pop_size.join(

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -103,21 +103,15 @@ class InfectionWeightedAggregator(GeographicAggregator):
             ),
         )
 
-        assert set(
-            geo_map.keys()
-        ).issubset(
+        assert set(geo_map.keys()).issubset(
             set(forecast["division"].unique())
         ), 'All divisions in `geo_map.keys()` must be in `forecast["division"].'
 
-        assert set(
-            geo_map.keys()
-        ).issubset(
+        assert set(geo_map.keys()).issubset(
             set(pop_size["division"])
         ), 'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
 
-        assert set(
-            geo_map.keys()
-        ).issubset(
+        assert set(geo_map.keys()).issubset(
             set(prop_infected["division"])
         ), 'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
 

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -35,17 +35,17 @@ class ForecastFrame(pl.DataFrame):
         return cls(pl.read_parquet(*args, **kwargs))
 
     def validate(self):
-        assert self.REQUIRED_COLUMNS.issubset(self.columns), (
-            f"Missing required columns: ({', '.join(self.REQUIRED_COLUMNS - set(self.columns))})"
-        )
+        assert self.REQUIRED_COLUMNS.issubset(
+            self.columns
+        ), f"Missing required columns: ({', '.join(self.REQUIRED_COLUMNS - set(self.columns))})"
 
         proportion_sums = self.group_by(
             "sample_index", "fd_offset", "division"
         ).agg(pl.sum("phi"))
 
-        assert ((proportion_sums["phi"] - 1).abs() < 1e-3).all(), (
-            "Lineage proportions do not sum to 1."
-        )
+        assert (
+            (proportion_sums["phi"] - 1).abs() < 1e-3
+        ).all(), "Lineage proportions do not sum to 1."
 
 
 class GeographicAggregator(ABC):
@@ -109,17 +109,15 @@ class InfectionWeightedAggregator(GeographicAggregator):
 
         assert set(geo_map.keys()).issubset(
             set(forecast["division"].unique())
-        ), (
-            'All divisions in `geo_map.keys()` must be in `forecast["division"].'
-        )
+        ), 'All divisions in `geo_map.keys()` must be in `forecast["division"].'
 
-        assert set(geo_map.keys()).issubset(set(pop_size["division"])), (
-            'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
-        )
+        assert set(geo_map.keys()).issubset(
+            set(pop_size["division"])
+        ), 'All divisions in `geo_map.keys()` must be in `pop_size["division"].'
 
-        assert set(geo_map.keys()).issubset(set(prop_infected["division"])), (
-            'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
-        )
+        assert set(geo_map.keys()).issubset(
+            set(prop_infected["division"])
+        ), 'All divisions in `geo_map.keys()` must be in `prop_infected["division"].'
 
         weights = (
             pop_size.join(

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -41,7 +41,7 @@ class ForecastFrame(pl.DataFrame):
 
         assert self.REQUIRED_COLUMNS.issubset(
             self.columns
-        ), f"Missing at least one required column ({", ".join(self.REQUIRED_COLUMNS)})"
+        ), f"Missing at least one required column ({', '.join(self.REQUIRED_COLUMNS)})"
 
 
 class GeographicAggregator(ABC):

--- a/linmod/models/utils.py
+++ b/linmod/models/utils.py
@@ -49,7 +49,7 @@ class ForecastFrame(pl.DataFrame):
 
         assert (
             (proportion_sums["phi"] - 1).abs() < 1e-3
-        ).all(), f"Lineage proportions do not sum to 1."
+        ).all(), "Lineage proportions do not sum to 1."
 
 
 class GeographicAggregator(ABC):

--- a/linmod/tests/test_frames.py
+++ b/linmod/tests/test_frames.py
@@ -1,0 +1,130 @@
+import numpy as np
+import polars as pl
+import pytest
+from numpy.random import default_rng
+
+from linmod.data import CountsFrame
+from linmod.models import ForecastFrame
+from linmod.utils import expand_grid
+
+
+def _generate_fake_samples_and_data(
+    rng,
+    num_days,
+    num_divisions,
+    num_lineages,
+    num_samples,
+    sample_variance,
+):
+    r"""
+    Generate fake data $Y_{tgl}$ and "forecasts" $phi_{tgl}$.
+
+    - $Y_{tgl} \sim Uniform{0, ..., 99}$
+    - Denote true proportion as $\pi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
+    - $phi_{tgl} \sim N(\pi_{tgl}, \sigma^2)$
+    """
+
+    rng = default_rng(rng)
+
+    # Generate fake population counts
+    data = expand_grid(
+        fd_offset=range(num_days),
+        division=range(num_divisions),
+        lineage=range(num_lineages),
+    )
+
+    data = data.with_columns(
+        count=rng.integers(0, 100, data.shape[0]),
+        date=pl.col("fd_offset"),
+    )
+
+    # Generate fake forecasts of population proportions
+    samples = expand_grid(
+        fd_offset=range(num_days),
+        division=range(num_divisions),
+        lineage=range(num_lineages),
+        sample_index=range(num_samples),
+    ).join(
+        data.with_columns(
+            phi_mean=(
+                pl.col("count") / pl.sum("count").over("fd_offset", "division")
+            ),
+        ).drop("count"),
+        on=("fd_offset", "division", "lineage"),
+        how="left",
+        suffix="_sampled",
+    )
+
+    samples = samples.with_columns(
+        phi=rng.normal(samples["phi_mean"], np.sqrt(sample_variance))
+    ).drop("phi_mean")
+
+    return samples, data
+
+
+def test_countsframe():
+    REQUIRED_COLUMNS = {
+        "date",
+        "fd_offset",
+        "division",
+        "lineage",
+        "count",
+    }
+
+    rng = default_rng()
+
+    # Ensure proper data passes validation
+    _, data = _generate_fake_samples_and_data(
+        rng,
+        num_days=4,
+        num_divisions=3,
+        num_lineages=2,
+        num_samples=1000,
+        sample_variance=1.4,
+    )
+
+    CountsFrame(data).validate()
+
+    # Ensure null counts fail validation
+    data2 = data.with_columns(
+        count=pl.when(pl.col("fd_offset") == 0)
+        .then(None)
+        .otherwise(pl.col("count"))
+    )
+
+    with pytest.raises(AssertionError):
+        CountsFrame(data2).validate()
+
+    # Ensure missing columns fail validation
+    for col in REQUIRED_COLUMNS:
+        with pytest.raises(AssertionError):
+            CountsFrame(data.drop(col)).validate()
+
+
+def test_forecastframe():
+    REQUIRED_COLUMNS = {
+        "sample_index",
+        "fd_offset",
+        "division",
+        "lineage",
+        "phi",
+    }
+
+    rng = default_rng()
+
+    # Ensure proper data passes validation
+    samples, _ = _generate_fake_samples_and_data(
+        rng,
+        num_days=4,
+        num_divisions=3,
+        num_lineages=2,
+        num_samples=1000,
+        sample_variance=1.4,
+    )
+
+    ForecastFrame(samples).validate()
+
+    # Ensure missing columns fail validation
+    for col in REQUIRED_COLUMNS:
+        with pytest.raises(AssertionError):
+            CountsFrame(samples.drop(col)).validate()

--- a/linmod/tests/test_frames.py
+++ b/linmod/tests/test_frames.py
@@ -21,7 +21,7 @@ def _generate_fake_samples_and_data(
 
     - $Y_{tgl} \sim Uniform{0, ..., 99}$
     - Denote true proportion as $\pi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
-    - $phi_{tgl} \sim N(\pi_{tgl}, \sigma^2)$
+    - $phi_{tgl}' \sim N(\pi_{tgl}, \sigma^2); \phi_{tgl} = \frac{\phi_{tgl}'}{\Sum_{t',g'} \phi_{t'g'l}'}$
     """
 
     rng = default_rng(rng)


### PR DESCRIPTION
Resolves #67.

## Overview

Here we introduce two new classes, `linmod.data.CountsFrame` and `linmod.models.ForecastFrame`, to help us ensure the integrity of our count and proportion DataFrame.

These are subclasses of `pl.DataFrame`. Basic usage is to either pass an existing polars DataFrame into the constructor, or use the `read_parquet` class method. In either case, validation of the input is automatically performed.

Method signatures throughout the codebase have updated type hints, and pytests have been created for the validation routines of these objects.

## Validation details

`CountsFrame` ensures:
- All required columns are present (see `CountsFrame.REQUIRED_COLUMNS`)
- Null values are not present in any columns
- The `count` column is an integer type

`ForecastFrame` ensures:
- All required columns are present (see `ForecastFrame.REQUIRED_COLUMNS`)
- Lineage proportions for a given `(sample, date, division)` sum to (roughly) 1