### PR TITLE
Validate the join that an `Evaluator`'s constructor performs

### DIFF
--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -25,6 +25,11 @@ def multinomial_count_sampler(
 
 class ProportionsEvaluator:
     def __init__(self, samples: ForecastFrame, data: CountsFrame):
+        assert (
+            samples["lineage"].unique().sort()
+            == data["lineage"].unique().sort()
+        ).all()
+
         # Join the forecast samples and raw data dataframes.
         # Also compute the true proportions from the raw data.
         self.df = (
@@ -46,10 +51,6 @@ class ProportionsEvaluator:
             )
         )
 
-        assert (
-            self.df.shape[0]
-            == data.shape[0] * samples["sample_index"].n_unique()
-        )
         assert (
             self.df["fd_offset"].unique().sort()
             == data["fd_offset"].unique().sort()
@@ -163,6 +164,11 @@ class CountsEvaluator:
         )
         count_sampler = type(self)._count_samplers[count_sampler]
 
+        assert (
+            samples["lineage"].unique().sort()
+            == data["lineage"].unique().sort()
+        ).all()
+
         rng = np.random.default_rng(seed)
 
         self.df = (
@@ -187,10 +193,6 @@ class CountsEvaluator:
             .drop("phi_sampled")
         )
 
-        assert (
-            self.df.shape[0]
-            == data.shape[0] * samples["sample_index"].n_unique()
-        )
         assert (
             self.df["fd_offset"].unique().sort()
             == data["fd_offset"].unique().sort()

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -44,7 +44,18 @@ class ProportionsEvaluator:
                 how="left",
                 suffix="_sampled",
             )
-        ).lazy()
+        )
+
+        assert (
+            self.df.shape[0]
+            == data.shape[0] * samples["sample_index"].n_unique()
+        )
+        assert (
+            self.df["fd_offset"].unique().sort()
+            == data["fd_offset"].unique().sort()
+        ).all()
+
+        self.df = self.df.lazy()
 
     def _mean_norm_per_division_day(self, p=1) -> pl.LazyFrame:
         r"""
@@ -174,7 +185,18 @@ class CountsEvaluator:
             )
             .explode("lineage", "phi_sampled", "count", "count_sampled")
             .drop("phi_sampled")
-        ).lazy()
+        )
+
+        assert (
+            self.df.shape[0]
+            == data.shape[0] * samples["sample_index"].n_unique()
+        )
+        assert (
+            self.df["fd_offset"].unique().sort()
+            == data["fd_offset"].unique().sort()
+        ).all()
+
+        self.df = self.df.lazy()
 
     def _mean_norm_per_division_day(self, p=1) -> pl.LazyFrame:
         r"""

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -58,7 +58,7 @@ def _generate_fake_samples_and_data(
         phi=rng.normal(samples["phi_mean"], np.sqrt(sample_variance))
     ).drop("phi_mean")
 
-    return samples.lazy(), data.lazy()
+    return samples, data
 
 
 def test_proportions_mean_L1_norm(


### PR DESCRIPTION
Closes #24.

This is a short and sweet PR; I'm just making sure that when an `Evaluator`'s constructor joins samples and count data, we have the correct dates and number of rows in the resulting DataFrame.