### PR TITLE
Scoring changes

### DIFF
--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -118,7 +118,6 @@ class CountsEvaluator:
         data: CountsFrame,
         count_sampler: str = "multinomial",
         seed: int | None = None,
-        all_counts: pl.DataFrame | pl.LazyFrame | None = None,
     ) -> None:
         r"""
         Evaluates count forecasts $\hat{Y}$ sampled from a specified observation model given model
@@ -126,23 +125,7 @@ class CountsEvaluator:
 
         `count_sampler` should be one of the keys in `CountsEvaluator._count_samplers`.
         `seed` is an optional random seed for the count sampler.
-        `all_counts` is an optional way to feed in a pre-merged dataframe of observed and predicted counts
         """
-
-        if all_counts is not None:
-            assert set(all_counts.columns).issuperset(
-                [
-                    "count",
-                    "count_sampled",
-                    "lineage",
-                    "date",
-                    "fd_offset",
-                    "division",
-                    "sample_index",
-                ]
-            )
-            self.df = all_counts.lazy()
-            return None
 
         assert count_sampler in type(self)._count_samplers, (
             f"Count sampler '{count_sampler}' not found. "

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import numpy as np
 import polars as pl
 from numpy.random import default_rng
@@ -182,179 +184,34 @@ def test_proportions_mean_L1_norm2():
     )
 
 
-def test_proportions_L1_energy_score(
-    num_samples=100000, sample_variance=1.4, atol=0.05
-):
-    r"""
-    Test the estimate of the energy score of phi.
-
-    The setup is as follows:
-    - Generate fake data $Y_{tgl} \sim Uniform{0, ..., 99}$
-    - Denote true proportion as $\phi_{tgl} = \frac{Y_{tgl}}{Y_{tg \cdot}}$
-    - Generate fake "forecasts" $f_{tgl} \sim N(\phi_{tgl}, \sigma^2)$
-    - Check $$
-        \sum_{t, g} E[ || f_{tg} - \phi_{tg} ||_2 ]
-        - \frac{1}{2} E[ || f_{tg} - f_{tg}' ||_2 ]
-      $$ as reported by `eval.proportions_energy_score`
-
-    Note that our "forecasts" are not actually proportions, but independent normal
-    random variables. This is so that the quantity can be computed analytically.
-    """
-
-    rng = default_rng()
-
-    NUM_DAYS = 4
-    NUM_DIVISIONS = 3
-    NUM_LINEAGES = 2
-
-    samples, data = _generate_fake_samples_and_data(
-        rng,
-        num_days=NUM_DAYS,
-        num_divisions=NUM_DIVISIONS,
-        num_lineages=NUM_LINEAGES,
-        num_samples=num_samples,
-        sample_variance=sample_variance,
+def test_uncoverage():
+    df = pl.concat(
+        [
+            pl.DataFrame(
+                {
+                    "date": date(1, 1, 1),
+                    "fd_offset": [0] * 10,
+                    "division": [0] * 10,
+                    "lineage": ["A"] * 10,
+                    "count": [10] * 10,
+                    "sample_index": list(range(10)),
+                    "count_sampled": list(range(5, 15)),
+                }
+            ),
+            pl.DataFrame(
+                {
+                    "date": date(1, 1, 1),
+                    "fd_offset": [0] * 10,
+                    "division": [0] * 10,
+                    "lineage": ["B"] * 10,
+                    "count": [5] * 10,
+                    "sample_index": list(range(10)),
+                    "count_sampled": list(range(8, 18)),
+                }
+            ),
+        ]
     )
 
-    # Because we use L1 norm, term 1 is equal to the sum of each component's MAE from
-    # its mean.
-    # The mean absolute error of a normal random variable from its mean is
-    # $\sigma \sqrt{\frac{2}{\pi}}$ (because $X - \mu \sim N(0, \sigma^2)$, so
-    # $|X - \mu| \sim \text{half-normal}(\sigma)$, which has this mean).
+    evaluator = eval.CountsEvaluator(samples=None, data=None, all_counts=df)
 
-    term1 = (
-        np.sqrt(2 * sample_variance / np.pi)
-        * NUM_DAYS
-        * NUM_DIVISIONS
-        * NUM_LINEAGES
-    )
-
-    # Because we use L1 norm, term 2 is equal to the sum of each component's MAE from
-    # an independent copy of itself.
-    # The mean absolute error of a normal random variable from an independent copy is
-    # $\frac{2\sigma}{\sqrt{\pi}}$ (because $X - X' \sim N(0, 2 \sigma^2)$, so
-    # $|X - X'| \sim \text{half-normal}(\sqrt{2} \sigma)$, which has this mean).
-
-    term2 = (
-        (2 * np.sqrt(sample_variance / np.pi))
-        * NUM_DAYS
-        * NUM_DIVISIONS
-        * NUM_LINEAGES
-    )
-
-    assert np.isclose(
-        eval.ProportionsEvaluator(samples, data).energy_score(p=1),
-        term1 - 0.5 * term2,
-        atol=atol,
-    )
-
-
-def test_proportions_L1_energy_score2():
-    samples, data = _generate_fake_samples_and_data(
-        None,
-        num_days=2,
-        num_divisions=2,
-        num_lineages=2,
-        num_samples=3,
-        sample_variance=0,
-    )
-
-    # Put in fixed values for counts and phi
-    data = data.sort("fd_offset", "division", "lineage").with_columns(
-        count=pl.Series([1, 2, 3, 4, 5, 6, 7, 8]),
-    )
-
-    samples = samples.sort(
-        "fd_offset", "division", "sample_index", "lineage"
-    ).with_columns(
-        phi=pl.Series(
-            [
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.1,
-                0.9,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.1,
-                0.9,
-                0.2,
-                0.8,
-                0.3,
-                0.7,
-                0.1,
-                0.9,
-                0.4,
-                0.6,
-                0.5,
-                0.5,
-                0.1,
-                0.9,
-            ]
-        ),
-    )
-
-    correct_output = pl.DataFrame(
-        {
-            "fd_offset": [0, 0, 1, 1],
-            "division": [0, 1, 0, 1],
-            "energy_score": [
-                np.abs(np.array([0.2, 0.3, 0.1]) - 1 / (1 + 2)).mean()
-                + np.abs(np.array([0.8, 0.7, 0.9]) - 2 / (1 + 2)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-                ).mean(),
-                np.abs(np.array([0.4, 0.5, 0.1]) - 3 / (3 + 4)).mean()
-                + np.abs(np.array([0.6, 0.5, 0.9]) - 4 / (3 + 4)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-                ).mean(),
-                np.abs(np.array([0.2, 0.3, 0.1]) - 5 / (5 + 6)).mean()
-                + np.abs(np.array([0.8, 0.7, 0.9]) - 6 / (5 + 6)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.2, 0.3, 0.1]) - np.array([0.1, 0.2, 0.3])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.8, 0.7, 0.9]) - np.array([0.9, 0.8, 0.7])
-                ).mean(),
-                np.abs(np.array([0.4, 0.5, 0.1]) - 7 / (7 + 8)).mean()
-                + np.abs(np.array([0.6, 0.5, 0.9]) - 8 / (7 + 8)).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.4, 0.5, 0.1]) - np.array([0.1, 0.4, 0.5])
-                ).mean()
-                - 0.5
-                * np.abs(
-                    np.array([0.6, 0.5, 0.9]) - np.array([0.9, 0.6, 0.5])
-                ).mean(),
-            ],
-        }
-    )
-
-    result = (
-        eval.ProportionsEvaluator(samples, data)
-        ._energy_score_per_division_day(p=1)
-        .collect()
-    )
-
-    assert_frame_equal(
-        result,
-        correct_output,
-        check_row_order=False,
-        check_column_order=True,
-    )
+    assert evaluator.uncovered_proportion(alpha=0.1) == 0.5

--- a/linmod/tests/test_eval.py
+++ b/linmod/tests/test_eval.py
@@ -212,6 +212,11 @@ def test_uncoverage():
         ]
     )
 
-    evaluator = eval.CountsEvaluator(samples=None, data=None, all_counts=df)
-
+    evaluator = eval.CountsEvaluator(
+        samples=df.drop(["count_sampled", "count"]).with_columns(
+            phi=pl.lit(0.5)
+        ),
+        data=df.drop(["count_sampled", "sample_index"]).unique(),
+    )
+    evaluator.df = df.lazy()
     assert evaluator.uncovered_proportion(alpha=0.1) == 0.5


### PR DESCRIPTION
This PR:
- Adds an absolute scoring metric, the proportion of uncovered predictions, resolving #106 
- Deprecates the proportions energy score and associated tests, resolving #105 
- Adds machinery to filter score aggregations by lineages, divisions, and/or days, such that #104 can be resolved purely by changes to `retrospective-forecasting.main` and the input yamls.
- Deprecates some `LazyFrame` type hints that were making type checking in pylance very unhappy.
- Includes some random formatting changes `black` has gotten mad about since we last touched this code.

Out of scope:
- In removing the proportion energy score test, it becomes clear that we did not test the count-based energy score. We should remedy this. But getting that right is also dependent on _how_ we handle the energy score, which is currently in question.