### PR TITLE
Evaluating multiple different time ranges

### DIFF
--- a/linmod/data.py
+++ b/linmod/data.py
@@ -49,7 +49,7 @@ DEFAULT_CONFIG = {
         # Where should the UShER data be looked for? (Strong filepath assumptions are made about folders within this)
         "usher_root": "https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/",
         # Should we use cladecombiner.AsOfAggregator to ensure lineages are only those known as of the forecast_date?
-        "use_cladecombiner_as_of": True,
+        "use_cladecombiner_as_of": False,
         # Where (directory) should the unprocessed (but decompressed) data be stored?
         "cache_dir": ".cache/",
         # Where (files) should the processed datasets for modeling and evaluation

--- a/linmod/data.py
+++ b/linmod/data.py
@@ -49,7 +49,7 @@ DEFAULT_CONFIG = {
         # Where should the UShER data be looked for? (Strong filepath assumptions are made about folders within this)
         "usher_root": "https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/",
         # Should we use cladecombiner.AsOfAggregator to ensure lineages are only those known as of the forecast_date?
-        "use_cladecombiner_as_of": False,
+        "use_cladecombiner_as_of": True,
         # Where (directory) should the unprocessed (but decompressed) data be stored?
         "cache_dir": ".cache/",
         # Where (files) should the processed datasets for modeling and evaluation

--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -16,7 +16,7 @@ def optional_filter(df: pl.LazyFrame | pl.DataFrame, filters: dict | None):
         return df
     else:
         for col, vals in filters.items():
-            assert col in df.columns
+            assert col in df.lazy().collect_schema().names()
             if vals is not None:
                 df = df.filter(pl.col(col).is_in(vals))
 
@@ -197,7 +197,6 @@ class CountsEvaluator:
         Proportion of all lineage observation counts on all division-days not covered
         by the (central) 1 - alpha prediction interval.
         """
-        print(self._uncovered_per_lineage_division_day(alpha))
         prop = (
             self._uncovered_per_lineage_division_day(alpha)
             .pipe(optional_filter, filters=filters)

--- a/retrospective-forecasting/config/2022-early-omicron.yaml
+++ b/retrospective-forecasting/config/2022-early-omicron.yaml
@@ -67,6 +67,17 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/2022-early-omicron
 
+  # Each element of `filters` is a dictionary specifying filters for evaluation.
+  # Keys are columns in a ForecastFrame or CountsFrame, which will be filtered
+  # to only values in the dictionary values for that key (or null for no filter for that column).
+  # At least one filter must be specified, it may be null (to evaluate everything).
+  filters:
+    # Evaluate everything
+    everything: null
+    # Evaluate all lineages and divisions but only for the forecast date and period
+    forecast_days:
+      fd_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
   # How should forecasts be evaluated?
   metrics:
     - ProportionsEvaluator

--- a/retrospective-forecasting/config/2022-early-omicron.yaml
+++ b/retrospective-forecasting/config/2022-early-omicron.yaml
@@ -76,7 +76,7 @@ evaluation:
     everything: null
     # Evaluate all lineages and divisions but only for the forecast date and period
     forecast_days:
-      fd_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      fd_offset: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
 
   # How should forecasts be evaluated?
   metrics:

--- a/retrospective-forecasting/config/2023-variant-soup.yaml
+++ b/retrospective-forecasting/config/2023-variant-soup.yaml
@@ -67,6 +67,17 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/2023-variant-soup
 
+  # Each element of `filters` is a dictionary specifying filters for evaluation.
+  # Keys are columns in a ForecastFrame or CountsFrame, which will be filtered
+  # to only values in the dictionary values for that key (or null for no filter for that column).
+  # At least one filter must be specified, it may be null (to evaluate everything).
+  filters:
+    # Evaluate everything
+    everything: null
+    # Evaluate all lineages and divisions but only for the forecast date and period
+    forecast_days:
+      fd_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
   # How should forecasts be evaluated?
   metrics:
     - ProportionsEvaluator

--- a/retrospective-forecasting/config/2023-variant-soup.yaml
+++ b/retrospective-forecasting/config/2023-variant-soup.yaml
@@ -76,7 +76,7 @@ evaluation:
     everything: null
     # Evaluate all lineages and divisions but only for the forecast date and period
     forecast_days:
-      fd_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      fd_offset: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
 
   # How should forecasts be evaluated?
   metrics:

--- a/retrospective-forecasting/config/2024-nomenclature-shift.yaml
+++ b/retrospective-forecasting/config/2024-nomenclature-shift.yaml
@@ -67,6 +67,17 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/2024-nomenclature-shift
 
+  # Each element of `filters` is a dictionary specifying filters for evaluation.
+  # Keys are columns in a ForecastFrame or CountsFrame, which will be filtered
+  # to only values in the dictionary values for that key (or null for no filter for that column).
+  # At least one filter must be specified, it may be null (to evaluate everything).
+  filters:
+    # Evaluate everything
+    everything: null
+    # Evaluate all lineages and divisions but only for the forecast date and period
+    forecast_days:
+      fd_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
   # How should forecasts be evaluated?
   metrics:
     - ProportionsEvaluator

--- a/retrospective-forecasting/config/2024-nomenclature-shift.yaml
+++ b/retrospective-forecasting/config/2024-nomenclature-shift.yaml
@@ -76,7 +76,7 @@ evaluation:
     everything: null
     # Evaluate all lineages and divisions but only for the forecast date and period
     forecast_days:
-      fd_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      fd_offset: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
 
   # How should forecasts be evaluated?
   metrics:

--- a/retrospective-forecasting/main.py
+++ b/retrospective-forecasting/main.py
@@ -206,25 +206,32 @@ with open(plot_script_file, "w") as plot_script:
                 **evaluator_args,
             )
 
-            for metric_name, metric_function in vars(type(evaluator)).items():
-                if metric_name.startswith("_"):
-                    continue
+            for filter_name, filter_set in config["evaluation"][
+                "filters"
+            ].items():
+                for metric_name, metric_function in vars(
+                    type(evaluator)
+                ).items():
+                    if metric_name.startswith("_"):
+                        continue
 
-                print_message(
-                    (
-                        f"Evaluating {model_name} model using "
-                        f"{evaluator_name}.{metric_name}..."
-                    ),
-                    end="",
-                )
-
-                scores.append(
-                    (
-                        f"{evaluator_name}.{metric_name}",
-                        model_name,
-                        metric_function(evaluator),
+                    print_message(
+                        (
+                            f"Evaluating {model_name} model using "
+                            f"{evaluator_name}.{metric_name} for "
+                            f"filter {filter_name}..."
+                        ),
+                        end="",
                     )
-                )
+
+                    scores.append(
+                        (
+                            f"{evaluator_name}.{metric_name}",
+                            filter_name,
+                            model_name,
+                            metric_function(evaluator, filters=filter_set),
+                        )
+                    )
 
                 print_message(" done.")
 
@@ -245,6 +252,6 @@ print_message("Success!")
 
 pl.DataFrame(
     scores,
-    schema=["Metric", "Model", "Score"],
+    schema=["Metric", "Subset", "Model", "Score"],
     orient="row",
 ).write_csv(eval_dir / "results.csv")

--- a/retrospective-forecasting/test/config.yaml
+++ b/retrospective-forecasting/test/config.yaml
@@ -74,6 +74,13 @@ evaluation:
   # Where (directory) should model scores and visualizations be stored?
   save_dir: out/eval/test/
 
+  # Each element of `filters` is a dictionary specifying filters for evaluation.
+  # Keys are columns in a ForecastFrame or CountsFrame, which will be filtered
+  # to only values in the dictionary values for that key (or null for no filter for that column).
+  # At least one filter must be specified, it may be null (to evaluate everything).
+  filters:
+    everything: null
+
   # How should forecasts be evaluated?
   metrics:
     - ProportionsEvaluator


### PR DESCRIPTION
This PR adjusts the pipeline, using the machinery from #107, so that we produce 2 evaluation results, one for all division-days (prior to this PR, this was what we were evaluating, overall model fit) and one for all divisions but only on days with `fd_offset >= 1` (the forecasting period, where there are no days which previously had any data).

It seemed easier to make the interface slightly broader, rather than filter only on days to exactly specific ranges. So what is actually implemented is the ability to pass filters for any column of the combined forecast+count dataframe defining polars `.is_in()` filters. Thus it could also be used to evaluate only certain lineages on certain days in certain divisions.

Since #107 implements filtering when the statistic is computed, rather than upon initializing the evaluation object, we only draw one set of count data. This is both faster than drawing multiple and keeps the statistics aligned, as they're based on all the same counts.

Resolves #104.