### PR TITLE
Allow custom lineage names

### DIFF
--- a/linmod/data.py
+++ b/linmod/data.py
@@ -50,6 +50,8 @@ DEFAULT_CONFIG = {
         "usher_root": "https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/",
         # Should we use cladecombiner.AsOfAggregator to ensure lineages are only those known as of the forecast_date?
         "use_cladecombiner_as_of": True,
+        # Pre cladecombiner recoding of lineage names, as a {from : to} dict
+        "custom_relabelings": None,
         # Where (directory) should the unprocessed (but decompressed) data be stored?
         "cache_dir": ".cache/",
         # Where (files) should the processed datasets for modeling and evaluation
@@ -489,6 +491,14 @@ def main(cfg: Optional[dict]):
             full_df,
             usher_path=usher_cache_path,
             usher_lineage_from=config["data"]["usher_lineage_column_name"],
+        )
+
+    if config["data"]["custom_relabelings"] is not None:
+        print_message(
+            f"Relabeling lineages using map {config['data']['custom_relabelings']}."
+        )
+        full_df = full_df.with_columns(
+            pl.col("lineage").replace(config["data"]["custom_relabelings"])
         )
 
     if config["data"]["use_cladecombiner_as_of"]:

--- a/retrospective-forecasting/config/2024-nomenclature-shift.yaml
+++ b/retrospective-forecasting/config/2024-nomenclature-shift.yaml
@@ -27,6 +27,9 @@ data:
   # UShER recoding will use sequences from forecast_date + datetime.timedelta(days=usher_lag)
   usher_lag: 168
 
+  # Account for discrepancy between cladecombiner's as-of aggregation and recombinant handling
+  custom_relabelings: {"24F" : "recombinant"}
+
 forecasting:
   # Where (directory) should model output and visualizations be stored?
   save_dir: out/forecasts/2024-nomenclature-shift/


### PR DESCRIPTION
This PR adds the ability for users to relabel lineages in a custom way. This happens after UShER relabeling and before cladecombiner is called. 

The order of operations here is important, since using UShER labels overwrites lineage labels wholesale, and if we did this after cladecombiner as-of aggregation, we could not resolve #103 with this change.

If not using cladecombiner aggregation, this enables arbitary/custom aggregation of lineages, should that be desired.