### PR TITLE
Change CI alpha for proportion uncovered evaluator

### DIFF
--- a/linmod/eval.py
+++ b/linmod/eval.py
@@ -169,7 +169,7 @@ class CountsEvaluator:
 
         self.df = self.df.lazy()
 
-    def _uncovered_per_lineage_division_day(self, alpha=0.05):
+    def _uncovered_per_lineage_division_day(self, alpha=0.11):
         """
         For each lineage in each division on each day, False if the observed count in the
         (1 - alpha) x 100% univariate prediction interval, True otherwise.
@@ -192,7 +192,7 @@ class CountsEvaluator:
             )
         )
 
-    def uncovered_proportion(self, filters=None, alpha=0.05) -> float:
+    def uncovered_proportion(self, filters=None, alpha=0.11) -> float:
         """
         Proportion of all lineage observation counts on all division-days not covered
         by the (central) 1 - alpha prediction interval.


### PR DESCRIPTION
Preliminary results (e.g. https://github.com/CDCgov/cfa-viral-lineage-model/pull/109#issuecomment-3169109087) show that the forecasting distributions are overdispersed and cover more than they should.

This is a bit hard to see with the previous 95% intervals, so this PR swaps those for 89% intervals. E.g., the 95% interval for the Baseline model in nomenclature-shift covers about 97%, which _could_ be fine (it's only 2%, after all). but the 89% interval covers about 95% (and that seems more clearly overcovered). Meanwhile the nominal 89% interval for the ID model covers about 97%, which makes the point crystal clear.