### PR TITLE
Afm readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cfa-viral-lineage-model
 
-⚠️ The work in this repository is in progress and highly experimental. ⚠️
+⚠️ The work in this repository is experimental, though currently not under active development. ⚠️
 
 ## Overview
 
@@ -8,8 +8,13 @@ This repo hosts work on modeling how the composition of viral lineages, such as 
 
 The repo has the following structure:
 
-- `linmod/`, with a package for downloading lineage count data, and fitting and evaluating models with this data; and
+- `linmod/`, with a [poetry](https://python-poetry.org/docs/) package for downloading lineage count data, and fitting and evaluating models with this data; and
 - `retrospective-forecasting/`, with code that uses this package to automate the retrospective evaluation of models.
+
+### Documentation
+
+- [Documentation for linmnod](docs/) is best viewed with [mkdocs](https://www.mkdocs.org/). After cloning this repo and `poetry install`ing, run `poetry run mkdocs serve`.
+- For use of the restrospective-forecasting pipeline, see [the README](retrospective-forecasting/README.md).
 
 ### Architecture
 
@@ -35,47 +40,6 @@ Rows are uniquely identified by `(fd_offset, division, lineage, sample_index)`.
 | -30        | Alabama  | 22B     | 1            | 0.000014979599 |
 | -30        | Alabama  | 22B     | 2            | 9.945703e-7    |
 | ...        | ...      | ...     | ...          | ...            |
-
-
-## Milestones & timeline
-
-### Must-haves
-- [x] (1) Implement baseline and starter models
-	- Regression assuming spatial independence, no time covariate
-	- Regression assuming spatial independence and a time covariate
-- [x] (2) Design simulation study to verify model implementation
-- [x] (3) Implement a couple metrics to evaluate population-level lineage proportion forecasts in a retrospective setting
-- [x] (4) Conduct retrospective evaluations of our models with our metrics
-- [x] (5) Prepare for symposium & friends
-
-### Wishlist
-- [ ] (6) Implement a metric to evaluate population-level lineage domination time predictions in a retrospective setting
-	- Answer two questions: will lineage X take off? Given that lineage X takes off, at what time point does it reach 50% phi?
-- [ ] (7) Can we obtain lineage growth rates in a model-agnostic way, from only posterior samples of population-level lineage proportions?
-- [x] (8) Implement more advanced model and simulation study to verify
-	- Regression with information sharing over space
-- [ ] (9) Study more on how to set priors on the logit scale to induce priors on the probability simplex
-- [ ] (10) Does our ability to identify "good" models change if we evaluate daily vs weekly predictions?
-
-### A ladder of (multinomial logistic regression) models for consideration
-
-It seems useful to start at the bottom of the ladder, both for debugging purposes, but also to get a sense of the added predictive power of each step.
-You get more and more parameters to estimate; how does that balance against the improved accuracy?
-
-1. One human population/geography (e.g. state, HHS region, country), two pathogen populations (dominant variant vs. everything else), binomial dynamics
-   - i.e. `dominant% ~ invlogit[intercept + "slope" * time]`
-3. One geography, multiple variants, multinomial
-4. Multiple geographies, multiple variants, multinomial, no correlations or partial pooling
-   - Statistically equivalent to #2, but requires some different computational implementation
-5. As above plus partial pooling of "slopes" by variant across geographies, but without correlations:
-   - `beta_1ij ~ N(mu_beta1i, sigma_beta1i)`
-   - `mu_beta1i ~ some prior`, `sigma_beta1i ~ some prior`
-   - `i=variant` `j=geography`
-6. As above plus partial pooling of intercepts by variant across geographies
-7. As above plus correlations between "slopes" by variant across counties
-   - i.e. if growth rates of variant A and B are correlated across countries X and Y, then we also expect variants C and D to have correlated growth rates across countries X and Y
-   - `beta_1*j ~ MVN(mu_beta1*, Sigma)`
-   - `Sigma ~ some LKJ prior`
 
 ## General Disclaimer
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.

--- a/retrospective-forecasting/README.md
+++ b/retrospective-forecasting/README.md
@@ -19,3 +19,5 @@ Changes to analyses are made on a config by config basis.
 
 # Data provenance
 The population size data in are the 2023 estimates from [NST-EST2023-POP](https://www2.census.gov/programs-surveys/popest/tables/2020-2023/state/totals/NST-EST2023-POP.xlsx]).
+
+Vintaged Nextstrain and UShER data is available compressed from <https://zenodo.org/records/16942110>.


### PR DESCRIPTION
This PR adjusts the READMEs to:
- Point to the documentation.
- Point to the vintaged data available on zenodo.
- Remove the now unnecessary project timeline.

Resolves #111